### PR TITLE
feat(roadmap): Фаза D — разделы Spring / Hibernate / REST (Spring Boot 3, Java 21)

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,16 +32,16 @@
 
 ## Hibernate
 
-1. Hibernate _(в разработке)_
-2. Hibernate Criteria _(в разработке)_
+1. [Hibernate](src/main/resources/other/hibernate/hibernate.md)
+2. [Hibernate Criteria](src/main/resources/other/hibernate/hibernate-criteria.md)
 
 ## Spring / Spring Boot
 
-1. Spring _(в разработке)_
-2. Spring Boot _(в разработке)_
-3. Spring Data _(в разработке)_
-4. Spring Security _(в разработке)_
-5. Spring Cloud _(в разработке)_
+1. [Spring (Core, IoC/DI)](src/main/resources/other/spring/spring-core.md)
+2. [Spring Boot 3](src/main/resources/other/spring/spring-boot.md)
+3. [Spring Data JPA](src/main/resources/other/spring/spring-data.md)
+4. [Spring Security](src/main/resources/other/spring/spring-security.md)
+5. [Spring Cloud](src/main/resources/other/spring/spring-cloud.md)
 
 ## Other
 
@@ -63,7 +63,7 @@
     + Виды межсервисного взаимодействия
     + Архитектурные паттерны
     + Как покрывать тестами разные уровни программы
-10. REST _(в разработке)_
+10. [REST API](src/main/resources/other/rest/rest.md)
 11. Agile _(в разработке)_
 12. Scrum _(в разработке)_
 

--- a/src/main/resources/other/hibernate/hibernate-criteria.md
+++ b/src/main/resources/other/hibernate/hibernate-criteria.md
@@ -1,0 +1,553 @@
+# Hibernate/JPA Criteria API
+
+## Зачем это нужно / какую проблему решает
+
+Представь типичный экран каталога: пользователь ищет заказы. Сверху — панель фильтров: статус, продавец, диапазон дат, минимальная сумма, поиск по подстроке в номере. Любой из фильтров может быть заполнен, а может быть пустым. Комбинаций — сотни. Бэкенд обязан построить ровно один SQL-запрос, где `WHERE` содержит только те условия, что реально пришли.
+
+Первое, что делает почти каждый — собирает JPQL строкой:
+
+```java
+// НИКОГДА так не делайте
+String jpql = "SELECT o FROM SellerOrder o WHERE 1=1";
+if (status != null) {
+    jpql += " AND o.status = '" + status + "'";      // SQL-инъекция
+}
+if (search != null) {
+    jpql += " AND o.number LIKE '%" + search + "%'";  // и снова инъекция
+}
+if (minAmount != null) {
+    jpql += " AND o.amount >= " + minAmount;
+}
+```
+
+Что здесь не так — всё:
+
+- **SQL/JPQL-инъекция.** Конкатенация пользовательского ввода в текст запроса — классическая дыра. `status = "'; DROP ..."` — и вы в новостях.
+- **`WHERE 1=1` и ручная склейка `AND`.** Костыль, чтобы не думать, где ставить первый `AND`. Читается плохо, ломается легко.
+- **Опечатки ловятся только в рантайме.** Написали `o.stauts` — узнаете, когда упадёт запрос в проде, а не при компиляции.
+- **Рефакторинг ломает молча.** Переименовали поле `number` → `publicId` в сущности — строковый `"o.number"` про это не узнает. IDE не подсветит, тесты может не покрыть.
+- **Кошмар с параметрами и типами.** `LIKE '%...%'`, экранирование, даты, `IN (...)` с переменным числом элементов — всё руками.
+
+Правильный способ параметризации через `setParameter` спасает от инъекций, но не спасает от главной боли **динамических запросов**: когда набор условий заранее неизвестен, JPQL как строку всё равно приходится собирать кусками. Именно здесь выходит на сцену **Criteria API** — способ строить запрос из типобезопасных объектов-кирпичиков, а не из строки. Условия (`Predicate`) складываются в список, а финальный SQL Hibernate генерирует сам, корректно и с bind-параметрами.
+
+Criteria API — это «запрос как код»: компилятор проверяет структуру, IDE делает автодополнение и рефакторинг, а инъекции становятся невозможны by design.
+
+## Ключевые понятия
+
+### EntityManager и CriteriaBuilder
+
+Всё начинается с `EntityManager` (в Spring его дают инжектом через `@PersistenceContext` или получают из репозитория). Из него берётся **`CriteriaBuilder`** — фабрика всего: запросов, предикатов, выражений, сортировок.
+
+```java
+CriteriaBuilder cb = entityManager.getCriteriaBuilder();
+```
+
+Думай о `CriteriaBuilder` как о наборе функций-конструкторов: `cb.equal(...)`, `cb.like(...)`, `cb.and(...)`, `cb.greaterThanOrEqualTo(...)`, `cb.asc(...)`.
+
+### CriteriaQuery — сам запрос
+
+**`CriteriaQuery<T>`** — это дерево запроса: что выбираем (`select`), откуда (`from`), по какому условию (`where`), как сортируем (`orderBy`), как группируем (`groupBy`). Тип `<T>` — тип результата.
+
+```java
+CriteriaQuery<SellerOrder> query = cb.createQuery(SellerOrder.class);
+```
+
+### Root — точка входа в сущность
+
+**`Root<T>`** — это `FROM`-сущность и одновременно способ обращаться к её полям. `root.get("status")` — путь к атрибуту. Через `Root` строятся и джойны.
+
+```java
+Root<SellerOrder> root = query.from(SellerOrder.class);
+query.select(root);                       // SELECT o FROM SellerOrder o
+Path<Object> statusPath = root.get("status");
+```
+
+### Predicate — условие
+
+**`Predicate`** — одно логическое условие для `WHERE`/`HAVING`. Их можно собирать в список и комбинировать через `cb.and(...)`/`cb.or(...)`. Именно предикаты решают проблему динамики: не пришёл фильтр — не добавили предикат.
+
+```java
+List<Predicate> predicates = new ArrayList<>();
+predicates.add(cb.equal(root.get("status"), OrderStatus.PACKING));
+predicates.add(cb.greaterThanOrEqualTo(root.get("amount"), 1000L));
+query.where(cb.and(predicates.toArray(Predicate[]::new)));
+```
+
+### Expression, Order, join
+
+- **`Expression<T>`** — любое вычислимое значение: путь к полю, `cb.lower(path)`, `cb.count(root)`, арифметика.
+- **`Order`** — сортировка: `cb.asc(root.get("createdAt"))`.
+- **`Join`** — связь с другой сущностью: `root.join("items")`. Для загрузки связи в тот же запрос (борьба с N+1) — `root.fetch("items")`.
+
+### TypedQuery — выполнение
+
+`CriteriaQuery` — это только описание. Чтобы выполнить, оборачиваем в `TypedQuery` через тот же `EntityManager`:
+
+```java
+List<SellerOrder> result = entityManager.createQuery(query).getResultList();
+```
+
+### Metamodel: `get("status")` vs `SellerOrder_.status`
+
+Строковый `root.get("status")` — типобезопасен по структуре запроса, но имя поля всё ещё строка. Настоящая типобезопасность — **JPA Static Metamodel**: аннотационный процессор Hibernate генерирует класс `SellerOrder_` с полями-атрибутами.
+
+```java
+root.get(SellerOrder_.status)   // компилятор проверит и поле, и его тип
+```
+
+Переименовали поле — код с `SellerOrder_.status` перестанет компилироваться. Это и есть «typesafe».
+
+### Как это соотносится с JPQL и Spring Data Specifications
+
+- **JPQL** — компактно и читаемо для *статических* запросов, где условия фиксированы. Для динамики превращается в строковую склейку.
+- **Criteria API** — многословно, но идеально для *динамических* запросов и рефакторинг-безопасно.
+- **Spring Data JPA Specifications** — тонкая обёртка над Criteria API. `Specification<T>` — это, по сути, «фабрика `Predicate`», которые удобно комбинировать (`Specification.where(a).and(b)`). Под капотом — всё тот же `CriteriaBuilder`. В боевом Spring-коде чаще пишут именно Specifications, а голый Criteria API — когда нужен полный контроль (сложные проекции, подзапросы, агрегаты).
+
+Правило выбора: **фиксированный запрос → JPQL/`@Query`; динамический набор фильтров → Specifications (или Criteria API напрямую).**
+
+## Примеры на Java
+
+### Сущность (Jakarta, не javax!)
+
+```java
+package com.example.orders.model;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Table(name = "seller_order")
+public class SellerOrder {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String number;
+
+    @Column(name = "seller_id", nullable = false)
+    private Long sellerId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private OrderStatus status;
+
+    @Column(nullable = false)
+    private Long amount;
+
+    @Column(name = "created_at", nullable = false)
+    private Instant createdAt;
+
+    // LAZY по умолчанию — грузим связь осознанно через fetch/join
+    @OneToMany(mappedBy = "order", fetch = FetchType.LAZY)
+    private List<OrderItem> items = new ArrayList<>();
+
+    protected SellerOrder() { } // требуется JPA
+
+    // геттеры опущены для краткости
+}
+```
+
+```java
+package com.example.orders.model;
+
+public enum OrderStatus {
+    CREATED, PACKING, DELIVERING, COMPLETED, CANCELED
+}
+```
+
+### DTO фильтра и критерии приёмки запроса (record — Java 21)
+
+```java
+package com.example.orders.web;
+
+import com.example.orders.model.OrderStatus;
+import java.time.Instant;
+
+// null-поле = фильтр не задан
+public record OrderFilter(
+        OrderStatus status,
+        Long sellerId,
+        String numberContains,
+        Long minAmount,
+        Instant createdFrom,
+        Instant createdTo
+) { }
+```
+
+### Репозиторий на «голом» Criteria API
+
+Это `@Repository` (слой доступа к данным). Бизнес-логики здесь нет — только сборка запроса.
+
+```java
+package com.example.orders.repository;
+
+import com.example.orders.model.OrderStatus;
+import com.example.orders.model.SellerOrder;
+import com.example.orders.web.OrderFilter;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import jakarta.persistence.criteria.CriteriaBuilder;
+import jakarta.persistence.criteria.CriteriaQuery;
+import jakarta.persistence.criteria.Predicate;
+import jakarta.persistence.criteria.Root;
+import java.util.ArrayList;
+import java.util.List;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public class SellerOrderCriteriaRepository {
+
+    @PersistenceContext
+    private EntityManager em;
+
+    public List<SellerOrder> search(OrderFilter filter, int page, int size) {
+        CriteriaBuilder cb = em.getCriteriaBuilder();
+        CriteriaQuery<SellerOrder> query = cb.createQuery(SellerOrder.class);
+        Root<SellerOrder> root = query.from(SellerOrder.class);
+
+        List<Predicate> predicates = buildPredicates(cb, root, filter);
+
+        query.select(root)
+                .where(cb.and(predicates.toArray(Predicate[]::new)))
+                .orderBy(cb.desc(root.get("createdAt")));
+
+        return em.createQuery(query)
+                .setFirstResult(page * size)   // пагинация: OFFSET
+                .setMaxResults(size)           // LIMIT
+                .getResultList();
+    }
+
+    // Сборка предикатов — сердце динамического запроса.
+    // Условие добавляется в список ТОЛЬКО если фильтр реально задан.
+    private List<Predicate> buildPredicates(CriteriaBuilder cb,
+                                            Root<SellerOrder> root,
+                                            OrderFilter f) {
+        List<Predicate> predicates = new ArrayList<>();
+
+        if (f.status() != null) {
+            predicates.add(cb.equal(root.get("status"), f.status()));
+        }
+        if (f.sellerId() != null) {
+            predicates.add(cb.equal(root.get("sellerId"), f.sellerId()));
+        }
+        if (f.numberContains() != null && !f.numberContains().isBlank()) {
+            // регистронезависимый LIKE; параметр биндится, инъекция невозможна
+            predicates.add(cb.like(
+                    cb.lower(root.get("number")),
+                    "%" + f.numberContains().toLowerCase() + "%"));
+        }
+        if (f.minAmount() != null) {
+            predicates.add(cb.greaterThanOrEqualTo(root.get("amount"), f.minAmount()));
+        }
+        if (f.createdFrom() != null) {
+            predicates.add(cb.greaterThanOrEqualTo(root.get("createdAt"), f.createdFrom()));
+        }
+        if (f.createdTo() != null) {
+            predicates.add(cb.lessThan(root.get("createdAt"), f.createdTo()));
+        }
+
+        return predicates;
+    }
+
+    // Пример агрегата: сколько заказов в статусе у продавца
+    public long countByStatus(Long sellerId, OrderStatus status) {
+        CriteriaBuilder cb = em.getCriteriaBuilder();
+        CriteriaQuery<Long> query = cb.createQuery(Long.class);
+        Root<SellerOrder> root = query.from(SellerOrder.class);
+
+        query.select(cb.count(root))
+                .where(cb.and(
+                        cb.equal(root.get("sellerId"), sellerId),
+                        cb.equal(root.get("status"), status)));
+
+        return em.createQuery(query).getSingleResult();
+    }
+}
+```
+
+### То же самое через Spring Data Specifications (рекомендуемый способ в Spring-проектах)
+
+Спецификация — переиспользуемая «фабрика предиката». Их удобно комбинировать.
+
+```java
+package com.example.orders.repository;
+
+import com.example.orders.model.OrderStatus;
+import com.example.orders.model.SellerOrder;
+import java.time.Instant;
+import org.springframework.data.jpa.domain.Specification;
+
+public final class OrderSpecifications {
+
+    private OrderSpecifications() { }
+
+    public static Specification<SellerOrder> hasStatus(OrderStatus status) {
+        // возвращаем null, если фильтр не задан — Spring Data сам его отбросит
+        return status == null
+                ? null
+                : (root, query, cb) -> cb.equal(root.get("status"), status);
+    }
+
+    public static Specification<SellerOrder> numberContains(String text) {
+        if (text == null || text.isBlank()) {
+            return null;
+        }
+        return (root, query, cb) ->
+                cb.like(cb.lower(root.get("number")), "%" + text.toLowerCase() + "%");
+    }
+
+    public static Specification<SellerOrder> amountAtLeast(Long min) {
+        return min == null
+                ? null
+                : (root, query, cb) -> cb.greaterThanOrEqualTo(root.get("amount"), min);
+    }
+
+    public static Specification<SellerOrder> createdBetween(Instant from, Instant to) {
+        return (root, query, cb) -> {
+            if (from != null && to != null) {
+                return cb.between(root.get("createdAt"), from, to);
+            }
+            if (from != null) {
+                return cb.greaterThanOrEqualTo(root.get("createdAt"), from);
+            }
+            if (to != null) {
+                return cb.lessThan(root.get("createdAt"), to);
+            }
+            return null;
+        };
+    }
+}
+```
+
+```java
+package com.example.orders.repository;
+
+import com.example.orders.model.SellerOrder;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
+
+// JpaSpecificationExecutor даёт findAll(Specification, Pageable) из коробки
+public interface SellerOrderRepository
+        extends JpaRepository<SellerOrder, Long>,
+                JpaSpecificationExecutor<SellerOrder> {
+}
+```
+
+### Сервис — здесь бизнес-логика и оркестрация
+
+```java
+package com.example.orders.service;
+
+import com.example.orders.model.SellerOrder;
+import com.example.orders.repository.OrderSpecifications;
+import com.example.orders.repository.SellerOrderRepository;
+import com.example.orders.web.OrderFilter;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.jpa.domain.Specification;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class OrderSearchService {
+
+    private final SellerOrderRepository repository;
+
+    // Конструкторная инъекция — не полевая. Тестируемо и final.
+    public OrderSearchService(SellerOrderRepository repository) {
+        this.repository = repository;
+    }
+
+    @Transactional(readOnly = true)
+    public Page<SellerOrder> search(OrderFilter filter, int page, int size) {
+        Specification<SellerOrder> spec = Specification
+                .where(OrderSpecifications.hasStatus(filter.status()))
+                .and(OrderSpecifications.numberContains(filter.numberContains()))
+                .and(OrderSpecifications.amountAtLeast(filter.minAmount()))
+                .and(OrderSpecifications.createdBetween(
+                        filter.createdFrom(), filter.createdTo()));
+
+        var pageable = PageRequest.of(page, size, Sort.by("createdAt").descending());
+        return repository.findAll(spec, pageable);
+    }
+}
+```
+
+### Контроллер — тонкий
+
+```java
+package com.example.orders.web;
+
+import com.example.orders.model.OrderStatus;
+import com.example.orders.model.SellerOrder;
+import com.example.orders.service.OrderSearchService;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import java.time.Instant;
+import org.springframework.data.domain.Page;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.validation.annotation.Validated;
+
+@RestController
+@Validated
+public class OrderSearchController {
+
+    private final OrderSearchService searchService;
+
+    public OrderSearchController(OrderSearchService searchService) {
+        this.searchService = searchService;
+    }
+
+    @GetMapping("/api/orders")
+    public Page<SellerOrder> search(
+            @RequestParam(required = false) OrderStatus status,
+            @RequestParam(required = false) Long sellerId,
+            @RequestParam(required = false) String numberContains,
+            @RequestParam(required = false) Long minAmount,
+            @RequestParam(required = false) Instant createdFrom,
+            @RequestParam(required = false) Instant createdTo,
+            @RequestParam(defaultValue = "0") @Min(0) int page,
+            @RequestParam(defaultValue = "20") @Min(1) @Max(100) int size) {
+
+        var filter = new OrderFilter(
+                status, sellerId, numberContains, minAmount, createdFrom, createdTo);
+        return searchService.search(filter, page, size);
+    }
+}
+```
+
+### Включаем static metamodel (typesafe get)
+
+Подключаем аннотационный процессор Hibernate — он сгенерирует `SellerOrder_`:
+
+```groovy
+// build.gradle
+dependencies {
+    annotationProcessor 'org.hibernate.orm:hibernate-jpamodelgen:6.6.0.Final'
+}
+```
+
+После сборки в коде можно писать `root.get(SellerOrder_.status)` вместо `root.get("status")` — и получить проверку на этапе компиляции.
+
+### Пример конфигурации (application.yml)
+
+```yaml
+spring:
+  datasource:
+    url: jdbc:postgresql://localhost:5432/orders
+    username: ${DB_USER}          # секреты — из переменных окружения, НЕ в yml
+    password: ${DB_PASSWORD}
+  jpa:
+    hibernate:
+      ddl-auto: validate          # схему ведём миграциями (Liquibase/Flyway), не Hibernate
+    properties:
+      hibernate:
+        format_sql: true
+    open-in-view: false           # выключаем OSIV: LazyInit только в транзакции сервиса
+```
+
+## Частые ошибки / подводные камни
+
+### 1. Строковая конкатенация JPQL/SQL вместо предикатов
+
+Главная причина этого урока. Любая склейка пользовательского ввода в текст запроса — инъекция и невозможность рефакторинга. Динамику собираем списком `Predicate` (или комбинацией `Specification`), значения всегда идут bind-параметрами.
+
+### 2. N+1 при обращении к LAZY-связи
+
+Выбрали 100 заказов, потом в цикле дёрнули `order.getItems()` — Hibernate сделает 1 + 100 запросов. В Criteria лечится fetch-join:
+
+```java
+root.fetch("items", JoinType.LEFT);
+query.distinct(true);   // fetch коллекции размножает строки — нужен distinct
+```
+
+Осторожно: **fetch коллекции ломает пагинацию** (`setMaxResults` в этом случае применяется в памяти — Hibernate предупредит в логе `HHH000104`). Для «список + связь + пагинация» используй двухшаговый подход: сначала выбери ID страницы, потом отдельным запросом подтяни связи по этим ID.
+
+### 3. `open-in-view: true` (по умолчанию — включено!)
+
+Spring Boot по умолчанию держит `EntityManager` открытым до конца HTTP-ответа. LAZY-поля тогда «дозагружаются» при сериализации в контроллере — незаметный N+1 и запросы вне транзакции сервиса. Ставь `spring.jpa.open-in-view: false` и грузи всё нужное явно (fetch/`@EntityGraph`) внутри `@Transactional`-метода сервиса.
+
+### 4. Полевая инъекция вместо конструкторной
+
+```java
+@Autowired private SellerOrderRepository repository;  // плохо
+```
+
+Поле нельзя сделать `final`, тяжело тестировать без Spring, скрываются циклические зависимости. Всегда — конструктор (в single-конструкторе `@Autowired` даже не нужен).
+
+### 5. `@Transactional` на private-методе или при self-invocation
+
+`@Transactional` работает через Spring-прокси. Аннотация на `private`-методе — молча игнорируется. Вызов `this.otherTransactional()` внутри того же бина минует прокси — транзакция не откроется. Транзакционный метод должен быть `public` и вызываться извне (через инжектированный бин).
+
+### 6. EAGER «на всякий случай»
+
+`@ManyToOne(fetch = EAGER)` / `@OneToMany(fetch = EAGER)` тянет связь в *каждом* запросе, даже когда она не нужна, — и порождает неубираемый N+1. Дефолт: связи — **LAZY**, а нужные грузим точечно fetch-join'ом или `@EntityGraph`.
+
+### 7. Забытый `query.select(root)` / неверный тип результата
+
+`createQuery(SellerOrder.class)`, но `select` указывает на `root.get("amount")` (тип `Long`) — рантайм-ошибка несоответствия типов. Тип `CriteriaQuery<T>`, `Root`, `select`-выражения и `getResultList()` должны быть согласованы. Для проекций заводи отдельный `CriteriaQuery<SomeDto>` с `cb.construct(SomeDto.class, ...)`.
+
+### 8. Секреты в конфиге
+
+Пароль БД строкой прямо в `application.yml`, закоммиченном в git — утечка. Секреты — через переменные окружения / vault, в yml только плейсхолдер `${DB_PASSWORD}`.
+
+> Тему устойчивости запросов к нагрузке (пагинация, rate limiting, идемпотентность повторных вызовов, ретраи при таймаутах БД) см. в разделе роадмапа **«Надёжность и архитектура»**.
+
+## Практическая задача
+
+**Контекст.** Ты пишешь бэкенд админ-панели маркетплейса. Менеджеры ищут заказы через форму с фильтрами. Форма растёт: продукт то и дело просит новый фильтр. Текущий код — портянка из `if` и склейки JPQL строкой; последний инцидент — менеджер ввёл в поиск апостроф, и запрос упал (а security-ревью нашло инъекцию).
+
+**Дано.**
+- Сущности `SellerOrder` (поля: `id`, `number`, `sellerId`, `status`, `amount`, `createdAt`) и связанная `OrderItem` (`id`, `order`, `productName`, `quantity`).
+- Эндпоинт `GET /api/admin/orders`.
+- Стек: Java 21, Spring Boot 3.x, PostgreSQL, Spring Data JPA.
+
+**ТЗ.** Реализуй поиск заказов через **динамические критерии** (Criteria API напрямую или через `Specification` — на твой выбор, но обоснуй). Поддержи фильтры (любая комбинация, любой может отсутствовать):
+
+1. `status` — точное совпадение.
+2. `sellerId` — точное совпадение.
+3. `numberContains` — регистронезависимая подстрока в `number`.
+4. `minAmount` / `maxAmount` — диапазон суммы (границы независимы).
+5. `createdFrom` / `createdTo` — диапазон дат.
+6. `productName` — заказы, у которых **хотя бы один** `OrderItem` содержит подстроку в `productName` (потребуется join и `distinct`).
+7. Сортировка по `createdAt DESC` и пагинация (`page`, `size`).
+
+**Критерии приёмки.**
+- В коде **нет** ни одной строковой конкатенации фрагментов запроса; все значения — bind-параметры.
+- Пустой фильтр (все параметры null) возвращает все заказы, страницами.
+- Поиск по `productName` не дублирует заказы, даже если совпало несколько позиций.
+- Апостроф/спецсимволы в текстовом поиске не ломают запрос и не выполняются как код.
+- Контроллер тонкий: только приём параметров и делегирование сервису. Бизнес-сборка — в сервисе/спеках.
+- Метод чтения помечен `@Transactional(readOnly = true)`, `open-in-view` выключен.
+- Есть функциональный тест (Testcontainers + PostgreSQL): проверь минимум три сценария — фильтр по статусу, по диапазону суммы, по `productName` без дублей.
+
+**Подсказки (без готового решения).**
+- Начни с `OrderFilter` (record) и списка `Predicate`, добавляемых по условию `!= null`.
+- Для `productName`: `Join<SellerOrder, OrderItem> items = root.join("items", JoinType.INNER)` + `query.distinct(true)`.
+- `Specification.where(a).and(b)` спокойно принимает `null`-спеки — используй это, чтобы не городить if вокруг комбинирования.
+- Для диапазона суммы, где заданы обе границы, есть `cb.between`; где одна — `greaterThanOrEqualTo` / `lessThanOrEqualTo`.
+- Проверь сгенерированный SQL (`hibernate.format_sql: true`, `logging.level.org.hibernate.SQL: DEBUG`) — убедись, что при пустом фильтре нет мусорного `WHERE 1=1` и что параметры именно биндятся.
+- Подумай, что будет с пагинацией при fetch-join коллекции (см. подводный камень №2) — и нужен ли тебе fetch именно здесь или достаточно `join`.
+
+## Что почитать
+
+- **Spring Data JPA — Specifications** (официальная дока): https://docs.spring.io/spring-data/jpa/reference/jpa/specifications.html
+- **Jakarta Persistence — Criteria API** (спецификация, актуальная для Jakarta EE / Spring Boot 3): https://jakarta.ee/specifications/persistence/3.1/jakarta-persistence-spec-3.1.html#a6925
+- **Hibernate 6 ORM User Guide — Criteria** (генерация metamodel, particularities): https://docs.jboss.org/hibernate/orm/6.6/userguide/html_single/Hibernate_User_Guide.html#criteria
+- **Baeldung — Spring Data JPA Specifications / Criteria queries**: https://www.baeldung.com/spring-data-criteria-queries

--- a/src/main/resources/other/hibernate/hibernate.md
+++ b/src/main/resources/other/hibernate/hibernate.md
@@ -1,0 +1,531 @@
+# Hibernate (ORM)
+
+## Зачем это нужно / какую проблему решает
+
+Представь, что ты пишешь сервис заказов. Есть таблица `orders`, таблица `order_item`, таблица `customer`. Тебе нужно достать заказ вместе с позициями и покупателем, показать их в API, а потом обновить статус. На голом JDBC один такой сценарий выглядит так:
+
+```java
+// Голый JDBC: достать заказ с позициями
+String sql = """
+    SELECT o.id, o.status, o.created_at,
+           i.id AS item_id, i.sku, i.qty, i.price
+    FROM orders o
+    LEFT JOIN order_item i ON i.order_id = o.id
+    WHERE o.id = ?
+    """;
+try (var ps = connection.prepareStatement(sql)) {
+    ps.setLong(1, orderId);
+    try (var rs = ps.executeQuery()) {
+        Order order = null;
+        while (rs.next()) {
+            if (order == null) {
+                order = new Order();
+                order.setId(rs.getLong("id"));
+                order.setStatus(OrderStatus.valueOf(rs.getString("status")));
+                order.setCreatedAt(rs.getTimestamp("created_at").toLocalDateTime());
+                order.setItems(new ArrayList<>());
+            }
+            long itemId = rs.getLong("item_id");
+            if (!rs.wasNull()) {
+                var item = new OrderItem();
+                item.setId(itemId);
+                item.setSku(rs.getString("sku"));
+                item.setQty(rs.getInt("qty"));
+                item.setPrice(rs.getBigDecimal("price"));
+                order.getItems().add(item);
+            }
+        }
+        return order;
+    }
+}
+```
+
+И это только чтение одного заказа. А ещё нужны: вставка с возвратом сгенерированного `id`, `UPDATE` только изменившихся полей, обработка `NULL`, конвертация типов (`Timestamp → LocalDateTime`, `String → enum`), схлопывание строк join'а в один объект с коллекцией. На каждый запрос — руками. Меняется схема — переписываешь маппинг в десятке мест. Это называется **object-relational impedance mismatch**: мир объектов (графы ссылок, наследование, коллекции) и мир таблиц (строки, внешние ключи, join'ы) устроены по-разному, и мост между ними ты строишь вручную снова и снова.
+
+**ORM (Object-Relational Mapping)** автоматизирует этот мост. Ты описываешь, какому классу соответствует какая таблица, а библиотека сама генерирует `SELECT/INSERT/UPDATE/DELETE`, конвертирует типы, собирает графы объектов и отслеживает изменения. Тот же сценарий на Hibernate:
+
+```java
+Order order = orderRepository.findById(orderId).orElseThrow();
+order.setStatus(OrderStatus.SHIPPED);   // UPDATE сгенерируется сам при коммите
+```
+
+Две строки вместо пятидесяти. Hibernate — самая распространённая реализация ORM для Java, и именно на ней по умолчанию работает Spring Data JPA.
+
+Важная оговорка, которую курс проговаривает жёстко: **ORM не отменяет знание SQL — он его прячет**. Пока всё работает, ты не видишь запросов. Когда прод тормозит из-за N+1 или неожиданного декартова произведения — тебе придётся читать сгенерированный SQL и понимать план выполнения. Поэтому SQL учат **до** Hibernate, а не вместо. Hibernate — это ускоритель для того, кто уже понимает, что происходит в базе.
+
+## Ключевые понятия
+
+### JPA vs Hibernate
+
+Это постоянная путаница у джунов, разложим раз и навсегда.
+
+- **JPA (Jakarta Persistence API)** — это **спецификация**, набор интерфейсов и аннотаций (`@Entity`, `@Id`, `EntityManager`, `@OneToMany`...). Сама по себе JPA ничего не делает — это контракт. В Spring Boot 3 пакет называется `jakarta.persistence.*` (раньше был `javax.persistence.*` — если видишь `javax`, это устаревший код под Java EE / Spring Boot 2, в нашем стеке так писать нельзя).
+- **Hibernate** — конкретная **реализация** этой спецификации (провайдер). Есть и другие (EclipseLink), но де-факто стандарт — Hibernate 6.x.
+- **Spring Data JPA** — надстройка Spring, которая избавляет от рутины: генерирует реализации репозиториев по интерфейсам, даёт `JpaRepository` с готовыми `save/findById/findAll`, деривацию запросов по имени метода.
+
+Иерархия по слоям: `твой код → Spring Data JPA → JPA (спека) → Hibernate (реализация) → JDBC → PostgreSQL`. Пишешь ты в основном против JPA-аннотаций и Spring Data, но понимать поведение нужно на уровне Hibernate, потому что именно он решает, какой SQL и когда выполнить.
+
+### @Entity, @Id, @GeneratedValue
+
+`@Entity` помечает класс как сущность — объект, который Hibernate умеет хранить в таблице. Каждой сущности нужен первичный ключ — поле с `@Id`.
+
+`@GeneratedValue` говорит, кто генерирует значение ключа. Ключевая для PostgreSQL стратегия — `IDENTITY` (колонка `BIGSERIAL` / `GENERATED ... AS IDENTITY`, база сама выдаёт id при вставке) либо `SEQUENCE` (Hibernate берёт значения из последовательности заранее и может батчить вставки).
+
+```java
+@Id
+@GeneratedValue(strategy = GenerationType.IDENTITY)
+private Long id;
+```
+
+Нюанс производительности: при `IDENTITY` Hibernate **не может** батчить `INSERT` — ему нужно узнать сгенерированный id сразу после каждой вставки. При `SEQUENCE` с `allocationSize` он резервирует диапазон id и вставляет пачкой. Для высоконагруженных вставок на PostgreSQL предпочтительнее `SEQUENCE`.
+
+### Связи: @OneToMany, @ManyToOne, @ManyToMany, mappedBy, каскады
+
+Связи между таблицами (внешние ключи) отображаются на ссылки между объектами.
+
+- **`@ManyToOne`** — «многие к одному». Много `OrderItem` ссылаются на один `Order`. Это **владеющая** сторона — здесь физически лежит внешний ключ (`order_item.order_id`).
+- **`@OneToMany`** — обратная сторона той же связи: у одного `Order` много `OrderItem`. Помечается `mappedBy = "order"` — это значит «я не владею связью, внешний ключ управляется полем `order` на другой стороне». Без `mappedBy` Hibernate решит, что это две разные связи, и создаст лишнюю join-таблицу.
+- **`@ManyToMany`** — «многие ко многим», через промежуточную таблицу. На практике часто лучше явно завести сущность-связку с `@ManyToOne` на обе стороны (чтобы хранить доп. поля вроде количества/даты).
+
+**Владеющая сторона важна:** Hibernate пишет в БД только по владеющей стороне. Если ты добавишь элемент в коллекцию `@OneToMany(mappedBy=...)`, но не проставишь обратную ссылку `@ManyToOne`, внешний ключ в базе не запишется. Поэтому заводят хелпер:
+
+```java
+public void addItem(OrderItem item) {
+    items.add(item);
+    item.setOrder(this);   // синхронизируем обе стороны
+}
+```
+
+**Каскады (`cascade`)** — какие операции пробрасывать с родителя на детей. `CascadeType.PERSIST` — сохранил заказ, сохранились и позиции. `CascadeType.ALL` включает всё, включая `REMOVE`. **`orphanRemoval = true`** — если убрал позицию из коллекции, она удалится из БД (сирота без родителя). Не ставь `CascadeType.REMOVE`/`ALL` на `@ManyToOne`, иначе удаление одной позиции может каскадно снести родительский заказ.
+
+### Жизненный цикл сущности: transient / persistent / detached / removed
+
+Объект-сущность в каждый момент находится в одном из состояний относительно **persistence context** (контекста персистентности, он же сессия Hibernate — живёт обычно в рамках одной транзакции):
+
+- **transient (новый)** — `new Order()`, Hibernate про него не знает, в БД записи нет.
+- **persistent (управляемый)** — объект привязан к контексту (после `save`/`persist` или после загрузки из БД). Hibernate следит за ним: любое изменение полей будет синхронизировано с БД при flush/commit. Это ключевое состояние.
+- **detached (отсоединённый)** — контекст закрылся (транзакция завершилась), объект остался в памяти, но за его изменениями Hibernate больше не следит. Чтобы снова управлять — `merge`.
+- **removed (удалённый)** — помечен на удаление (`remove`), `DELETE` уйдёт в БД при flush.
+
+Понимать это критично: одна и та же строка кода `order.setStatus(...)` в persistent-состоянии порождает `UPDATE`, а в detached — не делает ничего в базе. «Почему мои изменения не сохранились?» — почти всегда объект был detached (например, изменён вне транзакции).
+
+### Первый уровень кэша (L1)
+
+Persistence context — это ещё и **кэш первого уровня**. В пределах одной транзакции повторный `findById` с тем же id **не пойдёт в базу** — вернётся тот же самый объект из кэша. Гарантия: внутри одной сессии одному id соответствует ровно один экземпляр объекта (identity). L1-кэш включён всегда, его нельзя выключить, и он не разделяется между транзакциями/потоками.
+
+### Lazy vs Eager и проблема N+1
+
+Когда грузишь заказ, подтягивать ли сразу все его позиции? Это стратегия загрузки связи (`fetch`):
+
+- **LAZY (ленивая)** — связь грузится только при первом обращении к ней. Пока не вызвал `order.getItems()`, отдельного запроса нет. По умолчанию `@OneToMany` и `@ManyToMany` — LAZY.
+- **EAGER (жадная)** — связь грузится сразу вместе с сущностью. По умолчанию `@ManyToOne` и `@OneToOne` — EAGER.
+
+**Проблема N+1** — классические грабли ORM. Грузишь список из N заказов одним запросом, потом в цикле у каждого читаешь `getItems()` — и Hibernate делает по отдельному запросу на каждый заказ. Итого **1 + N** запросов вместо одного-двух. На 500 заказах это 501 обращение к БД.
+
+```java
+List<Order> orders = orderRepository.findAll();     // 1 запрос
+for (Order o : orders) {
+    o.getItems().size();                            // +N запросов (по одному на заказ!)
+}
+```
+
+Решение — загрузить связь заранее одним запросом: `JOIN FETCH` в JPQL или `@EntityGraph`. Именно ради контроля над N+1 и нужно уметь читать сгенерированный SQL (`spring.jpa.show-sql` / hibernate statistics).
+
+### Dirty checking (грязная проверка)
+
+Hibernate при загрузке запоминает снимок полей сущности. При flush он сравнивает текущее состояние со снимком и **сам** генерирует `UPDATE` для изменившихся сущностей. Тебе **не нужно** вызывать `save()` для уже управляемого объекта — достаточно поменять поле в рамках транзакции:
+
+```java
+@Transactional
+public void ship(Long orderId) {
+    Order order = orderRepository.findById(orderId).orElseThrow();
+    order.setStatus(OrderStatus.SHIPPED);   // всё; UPDATE уйдёт на коммите автоматически
+}
+```
+
+Обратная сторона: не вызывай `save()` в цикле бездумно и помни, что dirty checking стоит CPU на больших сессиях — для read-only операций ставь `@Transactional(readOnly = true)`, чтобы Hibernate не делал снимков и не пытался flush'ить.
+
+### Зачем сначала знать SQL
+
+Повторим, потому что это философия курса. Hibernate генерирует SQL за тебя, но:
+- N+1, декартовы взрывы при нескольких `JOIN FETCH` коллекций, лишние `UPDATE` — всё это видно только в сгенерированном SQL;
+- индексы, планы выполнения, транзакционные аномалии (см. раздел роадмапа про изоляцию транзакций) — вне зоны ответственности ORM;
+- сложную аналитику всё равно пишут нативным SQL.
+
+ORM — инструмент поверх SQL, а не замена ему. Джун, который «знает Hibernate, но не знает SQL», беспомощен ровно в тех местах, где Hibernate ломается.
+
+## Примеры на Java
+
+Реалистичный кусочек сервиса заказов: две связанные сущности, репозиторий, сервис, контроллер, конфиг. Всё на Java 21 / Spring Boot 3, импорты — `jakarta.*`.
+
+### Сущности
+
+```java
+package com.example.shop.order;
+
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Table(name = "orders")   // "order" — зарезервированное слово в SQL, поэтому orders
+public class Order {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Enumerated(EnumType.STRING)   // храним enum строкой, а не порядковым числом
+    @Column(nullable = false)
+    private OrderStatus status = OrderStatus.CREATED;
+
+    @Column(nullable = false, updatable = false)
+    private Instant createdAt = Instant.now();
+
+    // Владеет связью OrderItem (там лежит order_id). LAZY — не тянем позиции без надобности.
+    // cascade = ALL + orphanRemoval: позиции живут и умирают вместе с заказом.
+    @OneToMany(mappedBy = "order", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<OrderItem> items = new ArrayList<>();
+
+    protected Order() {
+        // JPA требует конструктор без аргументов
+    }
+
+    public Order(OrderStatus status) {
+        this.status = status;
+    }
+
+    // Хелпер синхронизирует обе стороны связи — иначе order_id не запишется
+    public void addItem(OrderItem item) {
+        items.add(item);
+        item.setOrder(this);
+    }
+
+    public void ship() {
+        if (status != OrderStatus.CREATED) {
+            throw new IllegalStateException("Отгрузить можно только новый заказ");
+        }
+        this.status = OrderStatus.SHIPPED;   // dirty checking сам сделает UPDATE
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public OrderStatus getStatus() {
+        return status;
+    }
+
+    public Instant getCreatedAt() {
+        return createdAt;
+    }
+
+    public List<OrderItem> getItems() {
+        return List.copyOf(items);   // наружу — неизменяемая копия
+    }
+}
+```
+
+```java
+package com.example.shop.order;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import java.math.BigDecimal;
+
+@Entity
+@Table(name = "order_item")
+public class OrderItem {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    // Владеющая сторона: внешний ключ order_id физически здесь.
+    // LAZY, хотя @ManyToOne по умолчанию EAGER — явно избегаем ненужной подгрузки заказа.
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "order_id", nullable = false)
+    private Order order;
+
+    @Column(nullable = false)
+    private String sku;
+
+    @Column(nullable = false)
+    private int qty;
+
+    @Column(nullable = false)
+    private BigDecimal price;
+
+    protected OrderItem() {
+    }
+
+    public OrderItem(String sku, int qty, BigDecimal price) {
+        this.sku = sku;
+        this.qty = qty;
+        this.price = price;
+    }
+
+    void setOrder(Order order) {   // package-private: дёргается только из Order.addItem
+        this.order = order;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public String getSku() {
+        return sku;
+    }
+
+    public int getQty() {
+        return qty;
+    }
+
+    public BigDecimal getPrice() {
+        return price;
+    }
+}
+```
+
+```java
+package com.example.shop.order;
+
+public enum OrderStatus {
+    CREATED, SHIPPED, DELIVERED, CANCELED
+}
+```
+
+### Репозиторий (Spring Data JPA) с решением N+1
+
+```java
+package com.example.shop.order;
+
+import java.util.List;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.EntityGraph;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+public interface OrderRepository extends JpaRepository<Order, Long> {
+
+    // JOIN FETCH — грузим заказ вместе с позициями ОДНИМ запросом (лечим N+1)
+    @Query("select distinct o from Order o join fetch o.items where o.id = :id")
+    Optional<Order> findByIdWithItems(Long id);
+
+    // Альтернатива через граф загрузки — декларативно указываем, что подтянуть
+    @EntityGraph(attributePaths = "items")
+    List<Order> findByStatus(OrderStatus status);
+}
+```
+
+### Сервис
+
+```java
+package com.example.shop.order;
+
+import java.util.List;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class OrderService {
+
+    private final OrderRepository orderRepository;
+
+    // Конструкторная инъекция: поля final, легко тестировать, без магии рефлексии
+    public OrderService(OrderRepository orderRepository) {
+        this.orderRepository = orderRepository;
+    }
+
+    @Transactional
+    public Long create(List<OrderItem> items) {
+        var order = new Order(OrderStatus.CREATED);
+        items.forEach(order::addItem);
+        // cascade = PERSIST сохранит и позиции; вернётся заказ с проставленным id
+        return orderRepository.save(order).getId();
+    }
+
+    @Transactional
+    public void ship(Long orderId) {
+        var order = orderRepository.findById(orderId)
+                .orElseThrow(() -> new OrderNotFoundException(orderId));
+        order.ship();   // save() не нужен — dirty checking сам сгенерирует UPDATE
+    }
+
+    @Transactional(readOnly = true)   // read-only: Hibernate не делает snapshot'ов, быстрее
+    public Order get(Long orderId) {
+        return orderRepository.findByIdWithItems(orderId)
+                .orElseThrow(() -> new OrderNotFoundException(orderId));
+    }
+}
+```
+
+### Контроллер (тонкий)
+
+```java
+package com.example.shop.order;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/orders")
+public class OrderController {
+
+    private final OrderService orderService;
+    private final OrderMapper orderMapper;   // сущность -> DTO, наружу Entity не отдаём
+
+    public OrderController(OrderService orderService, OrderMapper orderMapper) {
+        this.orderService = orderService;
+        this.orderMapper = orderMapper;
+    }
+
+    @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
+    public Long create(@RequestBody CreateOrderRequest request) {
+        return orderService.create(orderMapper.toItems(request));
+    }
+
+    @PostMapping("/{id}/ship")
+    public void ship(@PathVariable Long id) {
+        orderService.ship(id);
+    }
+
+    @GetMapping("/{id}")
+    public OrderResponse get(@PathVariable Long id) {
+        return orderMapper.toResponse(orderService.get(id));
+    }
+}
+```
+
+### Конфиг (application.yml)
+
+```yaml
+spring:
+  datasource:
+    # Секреты — из переменных окружения / секрет-менеджера, НЕ хардкодим в yml
+    url: jdbc:postgresql://localhost:5432/shop
+    username: ${DB_USER}
+    password: ${DB_PASSWORD}
+  jpa:
+    hibernate:
+      # validate: сверять схему с сущностями, но НЕ менять её. Схему ведёт миграция (Flyway/Liquibase).
+      ddl-auto: validate
+    properties:
+      hibernate:
+        # диалект PostgreSQL Hibernate 6 определяет сам — прописывать вручную обычно не нужно
+        format_sql: true
+        jdbc:
+          batch_size: 50          # батчинг INSERT/UPDATE (работает с SEQUENCE, не с IDENTITY)
+        order_inserts: true
+        order_updates: true
+    open-in-view: false           # ВЫКЛючить! иначе сессия висит до конца HTTP-запроса
+    show-sql: false               # в разработке можно true; в проде логируем через datasource-proxy
+```
+
+### Пример: как выглядит N+1 в SQL
+
+```sql
+-- Плохо: findAll() + обращение к items в цикле => 1 + N запросов
+SELECT id, status, created_at FROM orders;                 -- 1 раз
+SELECT id, sku, qty, price FROM order_item WHERE order_id = 1;  -- на каждый заказ
+SELECT id, sku, qty, price FROM order_item WHERE order_id = 2;
+-- ... ещё N-2 таких запроса
+
+-- Хорошо: findByStatus с @EntityGraph => один запрос
+SELECT o.id, o.status, o.created_at, i.id, i.sku, i.qty, i.price
+FROM orders o
+LEFT JOIN order_item i ON i.order_id = o.id
+WHERE o.status = 'CREATED';
+```
+
+## Частые ошибки / подводные камни
+
+1. **Полевая инъекция вместо конструкторной.** `@Autowired private OrderRepository repo;` мешает делать поля `final`, прячет зависимости, ломает тестируемость (нельзя создать объект без Spring-контекста) и допускает циклические зависимости. Всегда — конструкторная инъекция (в примерах выше). Один конструктор — `@Autowired` даже не нужен.
+
+2. **N+1 запросов.** Самая частая проблема производительности с ORM. LAZY-связь дёргается в цикле → шквал запросов. Лечится `JOIN FETCH` / `@EntityGraph` / batch-fetching (`@BatchSize`). Обязательно включай логирование SQL в разработке и смотри, сколько запросов реально уходит.
+
+3. **`@Transactional` на private-методе или при self-invocation.** Spring оборачивает бин прокси; аннотация на `private`/`protected`/package-private методе **не работает вообще**, а вызов `this.otherTransactionalMethod()` внутри того же класса идёт мимо прокси — транзакция не откроется. Транзакционный метод должен быть `public` и вызываться через бин (другой бин или self-инъекция). См. правило в архитектуре проекта.
+
+4. **EAGER везде.** Соблазн поставить `fetch = EAGER`, «чтобы всегда было под рукой», приводит к тому, что простой `findById` тянет пол-базы через каскад join'ов, а несколько EAGER-коллекций дают декартово произведение. Правило: **по умолчанию всё LAZY**, а нужные связи подтягивай точечно через fetch join под конкретный сценарий.
+
+5. **`open-in-view: true` (дефолт Spring Boot).** Держит persistence context открытым до конца рендеринга ответа — маскирует `LazyInitializationException`, но провоцирует N+1 в слое сериализации и держит соединение с БД дольше нужного. Выключай (`open-in-view: false`) и осознанно решай, что грузить в сервисном слое.
+
+6. **`ddl-auto: update`/`create` в проде и секреты в конфиге.** `ddl-auto` (кроме `validate`/`none`) даёт Hibernate менять схему автоматически — в проде это путь к потерянным данным и неконтролируемым миграциям; схему ведёт Flyway/Liquibase, а Hibernate только `validate`. Пароли/токены — в переменных окружения или секрет-менеджере, никогда не в `application.yml` в репозитории.
+
+7. **Отдача JPA-сущностей наружу из контроллера.** Сериализация LAZY-связей рвётся или, наоборот, тянет лишнее; поля утекают в API; изменение сущности ломает контракт. Наружу — DTO (record), маппинг через MapStruct или руками.
+
+## Практическая задача
+
+**Контекст.** Ты дорабатываешь тот самый сервис заказов. В админке появился экран «Активные заказы»: список всех заказов в статусе `CREATED` с их позициями и суммой каждого заказа. Разработчик до тебя сделал наивную реализацию — и на демо с 300 заказами страница открывалась 4 секунды, а в логах БД было видно несколько сотен запросов.
+
+**Дано.**
+- Сущности `Order` (1) — `OrderItem` (N), связь `@OneToMany(mappedBy = "order")`, LAZY.
+- Метод сервиса:
+  ```java
+  @Transactional(readOnly = true)
+  public List<OrderView> activeOrders() {
+      return orderRepository.findByStatus(OrderStatus.CREATED).stream()
+              .map(o -> new OrderView(
+                      o.getId(),
+                      o.getItems().stream()                       // <-- ленивое обращение
+                          .map(i -> i.getPrice().multiply(BigDecimal.valueOf(i.getQty())))
+                          .reduce(BigDecimal.ZERO, BigDecimal::add),
+                      o.getItems().size()))
+              .toList();
+  }
+  ```
+- `findByStatus` — обычный derived-метод без fetch.
+- Включён `open-in-view: false`.
+
+**Задача (ТЗ).**
+1. Объясни (2–3 предложения), почему запросов сотни и что именно порождает N+1.
+2. Перепиши загрузку так, чтобы заказы **с позициями** грузились **одним** SQL-запросом. Сделай это двумя независимыми способами: (а) через `@Query` с `join fetch`; (б) через `@EntityGraph`.
+3. Убедись, что при `open-in-view: false` доступ к `getItems()` не падает с `LazyInitializationException` — объясни, почему в твоём решении не падает.
+4. Дополнительно: если позиций у заказа может быть много, а по `@OneToMany` через `join fetch` возможны дубли строк — что нужно добавить в JPQL и почему это влияет на пагинацию.
+
+**Критерии приёмки.**
+- В логах на выборке активных заказов — **1** SQL-запрос вместо `1 + N` (проверяется через `spring.jpa.show-sql: true` или Hibernate statistics).
+- Оба варианта (`join fetch` и `@EntityGraph`) дают одинаковый результат и один запрос.
+- Нет `LazyInitializationException` и при этом `open-in-view` остаётся `false`.
+- Метод остаётся `@Transactional(readOnly = true)`.
+- Сущности наружу не отдаются — только `OrderView` (record).
+
+**Подсказки (без готового решения).**
+- Посчитай запросы до правки: включи `show-sql` и открой экран — сколько строк `select ... from order_item`?
+- `join fetch` инициализирует коллекцию сразу, поэтому обращение к `getItems()` уже не порождает нового запроса и работает вне открытой вью.
+- Для `@OneToMany` fetch join `distinct` в JPQL (или `hibernate.query.passDistinctThrough`) убирает дубли родителя; помни, что пагинация коллекций через fetch join небезопасна — Hibernate предупредит про «firstResult/maxResults ... applied in memory».
+- Подумай, нужен ли тебе вообще граф объектов ради суммы — иногда агрегат считается прямо в БД проекционным запросом (`select new OrderView(o.id, sum(...), count(...)) ... group by o.id`). Сравни оба подхода.
+
+## Что почитать
+
+- **Spring Boot 3 — Data Access / JPA** (официальная дока): https://docs.spring.io/spring-boot/reference/data/sql.html
+- **Spring Data JPA Reference** (репозитории, деривация запросов, `@EntityGraph`): https://docs.spring.io/spring-data/jpa/reference/jpa.html
+- **Hibernate 6 User Guide** (маппинг, жизненный цикл, fetching, батчинг): https://docs.jboss.org/hibernate/orm/6.6/userguide/html_single/Hibernate_User_Guide.html
+- **Baeldung — решение проблемы N+1 в Hibernate/JPA**: https://www.baeldung.com/spring-data-jpa-n-plus-1
+- **Spring Guide — Accessing Data with JPA**: https://spring.io/guides/gs/accessing-data-jpa
+
+> Смежные темы роадмапа: транзакции и уровни изоляции (раздел «Базы данных»), а идемпотентность, ретраи и rate limiting при работе с внешними системами — в разделе «Надёжность и архитектура».

--- a/src/main/resources/other/rest/rest.md
+++ b/src/main/resources/other/rest/rest.md
@@ -1,0 +1,677 @@
+# REST API
+
+## Зачем это нужно / какую проблему решает
+
+Представь: у тебя есть сервис заказов. Мобильное приложение хочет показать список заказов пользователя, веб-админка — отменить заказ, склад — отметить его собранным, а биллинг — раз в сутки выгрузить всё за вчера. Четыре разных клиента, написанных разными командами на разных языках, и все они должны говорить с твоим сервисом. Ты не можешь раздать им JDBC-доступ к своей базе (тогда любое изменение схемы сломает полмира), не можешь заставить всех подключить твою Java-библиотеку (Go-команда пошлёт тебя), и не можешь по каждому чиху созваниваться и договариваться о формате.
+
+Нужен **контракт поверх сети**, который:
+
+- понятен без документации на 200 страниц — по одному взгляду на `GET /orders/42` ясно, что это;
+- работает поверх того, что уже везде есть — HTTP, JSON, любой HTTP-клиент;
+- предсказуем — одинаковые запросы ведут себя одинаково, ошибки сообщаются машиночитаемо;
+- эволюционирует — можно добавить поле, не сломав старых клиентов.
+
+REST (Representational State Transfer) — это набор архитектурных принципов, который даёт такой контракт. Не протокол и не библиотека, а **стиль дизайна HTTP-API**: ты моделируешь предметную область как набор *ресурсов* с URL-адресами и работаешь с ними стандартными HTTP-методами. Именно поэтому REST стал лингва-франка межсервисного и клиент-серверного взаимодействия: он ничего нового не изобретает, а грамотно использует семантику HTTP, которую и так понимают все прокси, кэши, балансировщики и браузеры.
+
+Боль, которую REST убирает: «у нас на каждый эндпоинт свои правила, свои коды ошибок, `POST /getOrderById` рядом с `GET /order/delete`, и никто не помнит, что вернётся». REST задаёт скелет, внутри которого API становится угадываемым.
+
+## Ключевые понятия
+
+### Ресурс и его представление
+
+Центральная идея: сервер оперирует **ресурсами** — это любая сущность, на которую можно сослаться (заказ, товар, пользователь, коллекция заказов). У ресурса есть *идентификатор* (URL) и *представление* — то, как ресурс сериализуется для передачи (обычно JSON).
+
+Важно: URL адресует **существительное**, а не действие. Действие выражается HTTP-методом.
+
+```
+Плохо (глаголы в URL):   POST /createOrder, GET /getOrder?id=42, POST /order/42/cancelIt
+Хорошо (ресурсы):        POST /orders,      GET /orders/42,       POST /orders/42/cancellation
+```
+
+Ресурсы бывают:
+- **коллекции** — `/orders` (много заказов);
+- **элементы** — `/orders/42` (один конкретный);
+- **вложенные** — `/orders/42/items` (позиции внутри заказа 42);
+- иногда «действие как ресурс», когда операция не укладывается в CRUD — `/orders/42/cancellation` (создание отмены как под-ресурса).
+
+### HTTP-методы и их семантика
+
+| Метод    | Смысл                        | Тело запроса | Идемпотентен | Безопасен (read-only) |
+|----------|------------------------------|--------------|--------------|-----------------------|
+| `GET`    | получить ресурс/коллекцию    | нет          | да           | да                    |
+| `POST`   | создать / выполнить действие  | да           | **нет**      | нет                   |
+| `PUT`    | заменить ресурс целиком        | да           | да           | нет                   |
+| `PATCH`  | частично изменить ресурс       | да           | обычно нет   | нет                   |
+| `DELETE` | удалить ресурс                 | нет/да       | да           | нет                   |
+
+**Безопасный (safe)** метод не меняет состояние на сервере — `GET` можно вызывать сколько угодно, ничего не сломается (кэши и краулеры на это рассчитывают, не прячь мутации за GET).
+
+**Идемпотентный** метод даёт один и тот же итоговый эффект при повторе: один `DELETE /orders/42` или пять подряд — заказ в итоге удалён (последующие вернут `404`, но состояние то же). `PUT` заменяет ресурс целиком — повтор перезапишет теми же данными. А вот `POST /orders` идемпотентным **не является**: два вызова создадут два заказа. Идемпотентность — фундамент безопасных ретраев в ненадёжной сети (см. раздел роадмапа «Надёжность и архитектура»: ретраи, at-least-once доставка, дедупликация). Как сделать идемпотентными и мутации через `POST` — ниже в отдельном подразделе.
+
+`PATCH` формально не гарантирует идемпотентность (например, `PATCH`, увеличивающий счётчик на 1); но если ты патчишь конкретные поля конкретными значениями — на практике повтор безопасен.
+
+### Статус-коды
+
+Код ответа — это машиночитаемый итог операции. Клиент должен принимать решения по коду, а не парсить текст.
+
+- **2xx — успех:** `200 OK` (успешный GET/PUT/PATCH с телом), `201 Created` (ресурс создан — верни `Location` с URL нового ресурса), `202 Accepted` (принято в асинхронную обработку), `204 No Content` (успех без тела — типично для DELETE).
+- **3xx — перенаправление:** `304 Not Modified` (для условных запросов с кэшем).
+- **4xx — ошибка клиента (виноват запрос):** `400 Bad Request` (невалидное тело), `401 Unauthorized` (не аутентифицирован), `403 Forbidden` (аутентифицирован, но нет прав), `404 Not Found`, `409 Conflict` (конфликт состояния — например, отмена уже отменённого), `422 Unprocessable Entity` (синтаксис ок, но семантика невалидна), `429 Too Many Requests` (rate limit).
+- **5xx — ошибка сервера (виноват сервер):** `500 Internal Server Error`, `503 Service Unavailable`.
+
+Ключевой водораздел 4xx vs 5xx: 4xx — «не повторяй запрос как есть, он сам по себе плохой»; 5xx — «попробуй ещё раз позже, у меня проблема». От этого зависит, будет ли клиент ретраить.
+
+### Stateless
+
+REST требует, чтобы сервер **не хранил клиентскую сессию** между запросами: каждый запрос самодостаточен и несёт всё нужное для обработки (токен аутентификации, параметры). Сервер не помнит «этот клиент три запроса назад залогинился как Вася» в своей памяти.
+
+Зачем: любой запрос может уйти на любой инстанс за балансировщиком (горизонтальное масштабирование), инстанс можно перезапустить без потери сессий, не нужна липкая сессия (sticky session). Состояние живёт либо у клиента (JWT-токен в заголовке `Authorization`), либо во внешнем хранилище (Redis, БД) — но не в heap конкретного пода. Это ровно та причина, по которой в Spring Security 6 мы для REST-API выставляем `SessionCreationPolicy.STATELESS`.
+
+### Дизайн URL
+
+Практические правила, которые делают API угадываемым:
+
+- существительные во множественном числе: `/orders`, `/sellers`, `/orders/42/items`;
+- иерархия через вложенность, но не глубже 2 уровней: `/orders/42/items/7` — ок, `/a/1/b/2/c/3/d/4` — уже боль;
+- фильтрация, сортировка, пагинация — через query-параметры, не через URL-путь: `GET /orders?status=PACKING&sort=createdAt,desc&page=0&size=20`;
+- kebab-case для многословных сегментов: `/delivery-points`, не `/deliveryPoints` и не `/delivery_points`;
+- никаких расширений и глаголов: не `/orders/42.json`, не `/getOrders`.
+
+### Версионирование
+
+API меняется, а старые клиенты остаются. Ломающее изменение (убрали поле, поменяли тип, изменили семантику) требует новой версии. Стратегии:
+
+- **в пути:** `/api/v1/orders` — самый распространённый и прозрачный вариант, легко роутить;
+- **в заголовке / через media type:** `Accept: application/vnd.company.v2+json` — чище с точки зрения «URL адресует ресурс, а не версию», но сложнее в эксплуатации;
+- **в query:** `/orders?version=2` — не рекомендуется, ломает кэширование.
+
+На практике в микросервисах чаще всего берут версию в пути (`/v1`). Правило: **не ломай v1, пока по ней есть трафик**. Аддитивные изменения (добавил необязательное поле в ответ) версию не требуют — клиенты должны игнорировать неизвестные поля (в Jackson это `FAIL_ON_UNKNOWN_PROPERTIES=false`).
+
+### DTO и валидация
+
+Наружу нельзя отдавать JPA-сущности напрямую и нельзя принимать их же на вход. Причины: ленивая инициализация Hibernate внутри сериализации даёт `LazyInitializationException` и N+1; ты протекаешь внутреннюю схему БД в контракт; и клиент может прислать поля, которые ты не ждал (`id`, `version`, `createdAt`), а маппер их применит. Поэтому на границе — **DTO** (request/response), отдельно от доменной модели.
+
+DTO в Java 21 — это `record`: иммутабельный, лаконичный, с готовыми `equals/hashCode`. Валидация — через Jakarta Bean Validation (`jakarta.validation.*`) и `@Valid` на параметре контроллера: Spring прогонит аннотации (`@NotNull`, `@Size`, `@Positive`, `@Email`) до входа в бизнес-логику и на нарушении бросит `MethodArgumentNotValidException`, которую мы превратим в аккуратный `400`.
+
+### Обработка ошибок: ProblemDetail (RFC 7807/9457)
+
+Каждый эндпоинт ошибается по-разному — и если формат ошибки везде свой, клиент утонет. Стандарт **RFC 7807/9457** задаёт единое машиночитаемое тело ошибки — `application/problem+json`:
+
+```json
+{
+  "type": "https://api.company.com/errors/order-already-cancelled",
+  "title": "Order already cancelled",
+  "status": 409,
+  "detail": "Order 42 is already in status CANCELLED",
+  "instance": "/api/v1/orders/42/cancellation"
+}
+```
+
+В Spring Boot 3 для этого есть встроенный класс `ProblemDetail` и базовый `ResponseEntityExceptionHandler`, который уже умеет отдавать стандартные ошибки в этом формате. Централизуем всё в `@RestControllerAdvice`, чтобы контроллеры не были засыпаны `try/catch`.
+
+### Пагинация
+
+Никогда не возвращай неограниченную коллекцию — `GET /orders` без лимита однажды выберет миллион строк и положит и сервис, и клиент. Два подхода:
+
+- **offset-пагинация** (`?page=0&size=20`) — просто, но на больших смещениях `OFFSET 1000000` в PostgreSQL медленный, и при вставках между запросами страницы «съезжают». Годится для админок и небольших наборов.
+- **keyset / cursor-пагинация** (`?after=<last_id>&size=20`, `WHERE id > :lastId ORDER BY id LIMIT 20`) — стабильна и быстра на любых объёмах, но нельзя прыгнуть на произвольную страницу. Выбор для бесконечных лент и больших выгрузок.
+
+Spring Data отдаёт `Page<T>`/`Slice<T>` из `Pageable` — offset-пагинация «из коробки». В ответ полезно класть метаданные:总 total, номер страницы, размер.
+
+### Идемпотентность мутаций (Idempotency-Key)
+
+`POST /payments` создаёт платёж. Клиент отправил запрос, но ответ потерялся в сети (таймаут). Клиент ретраит — и создаёт **второй** платёж. Классика.
+
+Решение — паттерн **Idempotency-Key**: клиент генерирует уникальный ключ (UUID) на *логическую операцию* и шлёт его в заголовке `Idempotency-Key`. Сервер при первом запросе выполняет операцию и сохраняет `(ключ → результат)`; при повторе с тем же ключом — не выполняет заново, а возвращает сохранённый результат. Так небезопасный `POST` становится безопасным для ретраев. Это ровно то, что стандартизировали Stripe и другие платёжные API. Детали (окно хранения ключей, дедупликация в БД, конкурентные повторы) — тема раздела «Надёжность и архитектура».
+
+### HATEOAS (кратко)
+
+HATEOAS (Hypermedia as the Engine of Application State) — верхний «уровень зрелости» REST: ответ несёт не только данные, но и **ссылки на возможные следующие действия**. Клиент не хардкодит URL, а ходит по ссылкам, как браузер по гиперссылкам.
+
+```json
+{
+  "id": 42, "status": "PACKING",
+  "_links": {
+    "self":   { "href": "/api/v1/orders/42" },
+    "cancel": { "href": "/api/v1/orders/42/cancellation" },
+    "items":  { "href": "/api/v1/orders/42/items" }
+  }
+}
+```
+
+В Spring это Spring HATEOAS (`EntityModel`, `Link`). На практике в приватных микросервисах HATEOAS применяют редко — накладные расходы выше пользы, клиенты и так знают маршруты. Знать про него надо, тащить в каждый API — нет.
+
+### REST vs gRPC vs GraphQL (обзорно)
+
+- **REST/JSON** — универсален, человекочитаем, работает везде, отлично кэшируется по HTTP, легко дебажить (`curl`). Минусы: многословный JSON, over-/under-fetching (получаешь либо лишнее, либо мало и делаешь много запросов), нет строгой схемы из коробки (OpenAPI — опционально). Дефолт для публичных и большинства межсервисных API.
+- **gRPC** — бинарный protobuf поверх HTTP/2, строгая схема `.proto`, кодогенерация клиента/сервера, стриминг в обе стороны, низкая латентность. Минусы: не читается глазами, хуже с браузером (нужен gRPC-Web), сложнее дебажить. Выбор для высоконагруженного внутреннего трафика между сервисами.
+- **GraphQL** — один эндпоинт, клиент сам описывает, какие поля ему нужны (решает over/under-fetching), сильная типовая схема. Минусы: сложное кэширование, риск тяжёлых запросов (нужны глубина/сложность-лимиты), N+1 на резолверах (лечится dataloader). Хорош для агрегирующих BFF-слоёв под богатый фронтенд.
+
+Практический выбор: **REST по умолчанию**; gRPC — когда важна производительность внутренней связи; GraphQL — когда фронтенду нужна гибкая выборка из многих источников.
+
+## Примеры на Java
+
+Сквозной пример: сервис заказов. Сущность → репозиторий → DTO с валидацией → контроллер → глобальный обработчик ошибок → конфиг. Java 21, Spring Boot 3.x, Jakarta.
+
+### JPA-сущность (внутренняя модель, наружу не отдаётся)
+
+```java
+package com.example.orders.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import jakarta.persistence.Version;
+import java.time.Instant;
+
+@Entity
+@Table(name = "orders")
+public class Order {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String customerName;
+
+    @Enumerated(EnumType.STRING)     // храним строкой, а не ordinal — стабильно при добавлении статусов
+    @Column(nullable = false)
+    private OrderStatus status;
+
+    @Column(nullable = false)
+    private long amount;             // сумма в минимальных единицах (тийины/копейки), не double
+
+    @Column(nullable = false, updatable = false)
+    private Instant createdAt;
+
+    @Version                          // оптимистичная блокировка против гонок на update
+    private long version;
+
+    protected Order() {               // требуется JPA, не для прикладного кода
+    }
+
+    private Order(String customerName, long amount) {
+        this.customerName = customerName;
+        this.amount = amount;
+        this.status = OrderStatus.CREATED;
+        this.createdAt = Instant.now();
+    }
+
+    // фабрика вместо публичного конструктора/сеттеров — инвариант «новый заказ = CREATED»
+    public static Order create(String customerName, long amount) {
+        return new Order(customerName, amount);
+    }
+
+    // изменение состояния — через доменный метод, а не сеттер: сюда влезает бизнес-правило
+    public void cancel() {
+        if (status == OrderStatus.CANCELLED) {
+            throw new OrderAlreadyCancelledException(id);
+        }
+        if (status == OrderStatus.COMPLETED) {
+            throw new IllegalOrderStateException("Cannot cancel a completed order " + id);
+        }
+        this.status = OrderStatus.CANCELLED;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public String getCustomerName() {
+        return customerName;
+    }
+
+    public OrderStatus getStatus() {
+        return status;
+    }
+
+    public long getAmount() {
+        return amount;
+    }
+
+    public Instant getCreatedAt() {
+        return createdAt;
+    }
+}
+```
+
+```java
+package com.example.orders.domain;
+
+public enum OrderStatus {
+    CREATED, PACKING, DELIVERING, COMPLETED, CANCELLED
+}
+```
+
+### Репозиторий (Spring Data)
+
+```java
+package com.example.orders.domain;
+
+import java.util.Optional;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface OrderRepository extends JpaRepository<Order, Long> {
+
+    // пагинация «из коробки»: Spring Data сам добавит LIMIT/OFFSET и посчитает total
+    Page<Order> findByStatus(OrderStatus status, Pageable pageable);
+
+    Optional<Order> findByIdAndCustomerName(Long id, String customerName);
+}
+```
+
+### DTO — запрос и ответ (records + валидация)
+
+```java
+package com.example.orders.web;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Positive;
+import jakarta.validation.constraints.Size;
+
+// Тело POST /orders. Никаких id/status/createdAt — их задаёт сервер, не клиент.
+public record CreateOrderRequest(
+
+        @NotBlank(message = "customerName must not be blank")
+        @Size(max = 255)
+        String customerName,
+
+        @Positive(message = "amount must be positive")
+        long amount
+) {
+}
+```
+
+```java
+package com.example.orders.web;
+
+import com.example.orders.domain.Order;
+import java.time.Instant;
+
+// Ответ. Отдельный тип: контракт наружу не привязан к схеме БД.
+public record OrderResponse(
+        Long id,
+        String customerName,
+        String status,
+        long amount,
+        Instant createdAt
+) {
+    public static OrderResponse from(Order order) {
+        return new OrderResponse(
+                order.getId(),
+                order.getCustomerName(),
+                order.getStatus().name(),
+                order.getAmount(),
+                order.getCreatedAt()
+        );
+    }
+}
+```
+
+Обёртка для страницы — чтобы не отдавать «сырой» `Page` Spring Data (его JSON нестабилен между версиями):
+
+```java
+package com.example.orders.web;
+
+import java.util.List;
+import org.springframework.data.domain.Page;
+
+public record PageResponse<T>(List<T> content, int page, int size, long totalElements, int totalPages) {
+
+    public static <E, D> PageResponse<D> of(Page<E> page, java.util.function.Function<E, D> mapper) {
+        return new PageResponse<>(
+                page.getContent().stream().map(mapper).toList(),
+                page.getNumber(),
+                page.getSize(),
+                page.getTotalElements(),
+                page.getTotalPages()
+        );
+    }
+}
+```
+
+### Сервис (бизнес-логика, транзакции)
+
+```java
+package com.example.orders.domain;
+
+import com.example.orders.web.CreateOrderRequest;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class OrderService {
+
+    private final OrderRepository repository;
+
+    // конструкторная инъекция: поле final, бин неизменяем, легко тестировать
+    public OrderService(OrderRepository repository) {
+        this.repository = repository;
+    }
+
+    @Transactional
+    public Order create(CreateOrderRequest request) {
+        return repository.save(Order.create(request.customerName(), request.amount()));
+    }
+
+    @Transactional(readOnly = true)
+    public Order getById(Long id) {
+        return repository.findById(id)
+                .orElseThrow(() -> new OrderNotFoundException(id));
+    }
+
+    @Transactional(readOnly = true)
+    public Page<Order> list(OrderStatus status, Pageable pageable) {
+        return status == null
+                ? repository.findAll(pageable)
+                : repository.findByStatus(status, pageable);
+    }
+
+    @Transactional
+    public Order cancel(Long id) {
+        Order order = repository.findById(id)
+                .orElseThrow(() -> new OrderNotFoundException(id));
+        order.cancel();                 // бизнес-правило внутри домена; @Version защитит от гонки
+        return order;                    // dirty checking сохранит изменения на коммите
+    }
+}
+```
+
+### Контроллер (тонкий: принял → делегировал → вернул)
+
+```java
+package com.example.orders.web;
+
+import com.example.orders.domain.OrderService;
+import com.example.orders.domain.OrderStatus;
+import jakarta.validation.Valid;
+import java.net.URI;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/orders")   // версия в пути
+public class OrderController {
+
+    private final OrderService service;
+
+    public OrderController(OrderService service) {
+        this.service = service;
+    }
+
+    // POST /api/v1/orders -> 201 Created + Location на новый ресурс
+    @PostMapping
+    public ResponseEntity<OrderResponse> create(@Valid @RequestBody CreateOrderRequest request) {
+        var order = service.create(request);
+        var body = OrderResponse.from(order);
+        return ResponseEntity
+                .created(URI.create("/api/v1/orders/" + order.getId()))  // ставит и статус 201, и заголовок Location
+                .body(body);
+    }
+
+    // GET /api/v1/orders/42 -> 200 или 404 (через advice)
+    @GetMapping("/{id}")
+    public OrderResponse get(@PathVariable Long id) {
+        return OrderResponse.from(service.getById(id));
+    }
+
+    // GET /api/v1/orders?status=PACKING&page=0&size=20&sort=createdAt,desc
+    @GetMapping
+    public PageResponse<OrderResponse> list(
+            @RequestParam(required = false) OrderStatus status,
+            @PageableDefault(size = 20) Pageable pageable) {
+        return PageResponse.of(service.list(status, pageable), OrderResponse::from);
+    }
+
+    // POST /api/v1/orders/42/cancellation -> действие как под-ресурс
+    @PostMapping("/{id}/cancellation")
+    @ResponseStatus(HttpStatus.OK)
+    public OrderResponse cancel(@PathVariable Long id) {
+        return OrderResponse.from(service.cancel(id));
+    }
+}
+```
+
+### Доменные исключения
+
+```java
+package com.example.orders.domain;
+
+public class OrderNotFoundException extends RuntimeException {
+    public OrderNotFoundException(Long id) {
+        super("Order %d not found".formatted(id));
+    }
+}
+```
+
+```java
+package com.example.orders.domain;
+
+public class OrderAlreadyCancelledException extends RuntimeException {
+    public OrderAlreadyCancelledException(Long id) {
+        super("Order %d is already cancelled".formatted(id));
+    }
+}
+```
+
+```java
+package com.example.orders.domain;
+
+public class IllegalOrderStateException extends RuntimeException {
+    public IllegalOrderStateException(String message) {
+        super(message);
+    }
+}
+```
+
+### Глобальная обработка ошибок: @RestControllerAdvice + ProblemDetail (RFC 7807)
+
+```java
+package com.example.orders.web;
+
+import com.example.orders.domain.IllegalOrderStateException;
+import com.example.orders.domain.OrderAlreadyCancelledException;
+import com.example.orders.domain.OrderNotFoundException;
+import java.net.URI;
+import java.util.List;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.http.ProblemDetail;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.context.request.WebRequest;
+import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
+
+// Расширяем ResponseEntityExceptionHandler — он уже отдаёт стандартные Spring-ошибки как ProblemDetail
+@RestControllerAdvice
+public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
+
+    @ExceptionHandler(OrderNotFoundException.class)
+    public ProblemDetail handleNotFound(OrderNotFoundException ex) {
+        var problem = ProblemDetail.forStatusAndDetail(HttpStatus.NOT_FOUND, ex.getMessage());
+        problem.setTitle("Order not found");
+        problem.setType(URI.create("https://api.example.com/errors/order-not-found"));
+        return problem;
+    }
+
+    @ExceptionHandler({OrderAlreadyCancelledException.class, IllegalOrderStateException.class})
+    public ProblemDetail handleConflict(RuntimeException ex) {
+        var problem = ProblemDetail.forStatusAndDetail(HttpStatus.CONFLICT, ex.getMessage());
+        problem.setTitle("Order state conflict");
+        problem.setType(URI.create("https://api.example.com/errors/order-state-conflict"));
+        return problem;
+    }
+
+    // Ошибки @Valid: переопределяем метод базового класса, кладём разбор по полям в extension "errors"
+    @Override
+    protected ResponseEntity<Object> handleMethodArgumentNotValid(
+            MethodArgumentNotValidException ex,
+            HttpHeaders headers,
+            HttpStatusCode status,
+            WebRequest request) {
+
+        List<String> errors = ex.getBindingResult().getFieldErrors().stream()
+                .map(fe -> fe.getField() + ": " + fe.getDefaultMessage())
+                .toList();
+
+        var problem = ProblemDetail.forStatusAndDetail(HttpStatus.BAD_REQUEST, "Validation failed");
+        problem.setTitle("Invalid request");
+        problem.setType(URI.create("https://api.example.com/errors/validation"));
+        problem.setProperty("errors", errors);    // произвольное расширение поверх RFC 7807
+        return ResponseEntity.badRequest().body(problem);
+    }
+}
+```
+
+### Безопасность: stateless-конфиг (Spring Security 6, без WebSecurityConfigurerAdapter)
+
+```java
+package com.example.orders.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.Customizer;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+public class SecurityConfig {
+
+    // Компонентный стиль Spring Security 6: бин SecurityFilterChain вместо устаревшего adapter
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        http
+                // для stateless REST CSRF выключаем (нет cookie-сессии, защищаемся токеном)
+                .csrf(csrf -> csrf.disable())
+                // ключевое для REST: сервер не держит HTTP-сессию
+                .sessionManagement(sm -> sm.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .authorizeHttpRequests(auth -> auth
+                        .requestMatchers("/actuator/health/**").permitAll()
+                        .anyRequest().authenticated())
+                // ресурс-сервер: аутентификация по JWT из заголовка Authorization: Bearer ...
+                .oauth2ResourceServer(oauth -> oauth.jwt(Customizer.withDefaults()));
+        return http.build();
+    }
+}
+```
+
+### application.yml — важные для REST-контракта настройки
+
+```yaml
+spring:
+  jackson:
+    default-property-inclusion: non_null   # не сериализуем null-поля — компактнее и стабильнее контракт
+    deserialization:
+      fail-on-unknown-properties: false    # клиент прислал лишнее поле — не падаем (эволюция API)
+  mvc:
+    problemdetails:
+      enabled: true                        # включить ProblemDetail (RFC 7807) для стандартных ошибок
+  security:
+    oauth2:
+      resourceserver:
+        jwt:
+          issuer-uri: https://auth.example.com/realms/orders
+
+server:
+  error:
+    include-message: never                 # не протекаем внутренние сообщения в дефолтный error-ответ
+```
+
+### Схема таблицы (Liquibase/SQL)
+
+```sql
+CREATE TABLE orders (
+    id            BIGSERIAL PRIMARY KEY,
+    customer_name VARCHAR(255) NOT NULL,
+    status        VARCHAR(32)  NOT NULL,
+    amount        BIGINT       NOT NULL CHECK (amount > 0),
+    created_at    TIMESTAMPTZ  NOT NULL DEFAULT now(),
+    version       BIGINT       NOT NULL DEFAULT 0
+);
+
+-- индекс под частый фильтр GET /orders?status=...
+CREATE INDEX orders_status_idx ON orders (status);
+```
+
+## Частые ошибки / подводные камни
+
+1. **Полевая инъекция вместо конструкторной.** `@Autowired private OrderRepository repo;` мешает сделать поле `final`, прячет зависимости (класс с 12 полями выглядит невинно), ломает тестирование без Spring-контекста и позволяет создать наполовину собранный бин. Всегда — инъекция через конструктор, поле `final`. С одним конструктором `@Autowired` даже не нужен.
+
+2. **Отдача JPA-сущностей прямо из контроллера.** Сериализация сущности вне транзакции ловит `LazyInitializationException`; ленивые связи тянут N+1 прямо в Jackson; ты протекаешь схему БД в публичный контракт, и любой рефакторинг таблицы ломает клиентов. Плюс на входе Jackson может пробросить `id`/`version`/`status` из тела в сущность. Всегда — отдельные request/response DTO.
+
+3. **N+1 запросов на списках.** `GET /orders` вернул 50 заказов, а на сериализацию `order.getItems()` Hibernate сделал 50 отдельных `SELECT`. Лечится `@EntityGraph`/`join fetch` в репозитории (грузим связи одним запросом) или проекцией сразу в DTO. Всегда смотри реальный SQL (`spring.jpa.show-sql` в dev, а лучше p6spy/datasource-proxy).
+
+4. **`@Transactional` на private-методе или при self-invocation.** Spring оборачивает бин AOP-прокси; вызов `this.doWork()` внутри того же класса идёт мимо прокси — транзакция **не откроется**, и `@Transactional` на `private`/`protected`-методе просто игнорируется. Транзакционный метод должен быть `public` и вызываться через инъектированный бин (или вынеси его в отдельный сервис).
+
+5. **`FetchType.EAGER` везде.** «Чтобы не ловить LazyInit» ставят EAGER на все `@ManyToOne`/`@OneToMany` — и каждый запрос за заказом молча притаскивает половину базы, а на коллекциях EAGER рушит пагинацию (Hibernate тянет всё в память и лимитирует уже там). Дефолт — `LAZY`; нужные связи грузи явно через entity graph под конкретный сценарий.
+
+6. **Мутации под `GET` и неверные коды.** `GET /orders/42/delete`, который что-то удаляет, — кэши, прелоадеры браузера и краулеры такое дёргают сами и стирают данные. GET обязан быть безопасным. Смежная грабля — возвращать `200 OK` с телом `{"error": ...}` на ошибку: клиент по коду видит успех и не ретраит/не обрабатывает сбой. Код ответа должен отражать реальный итог (4xx/5xx).
+
+7. **Секреты в конфиге и в git.** Пароль БД или `client-secret` прямо в `application.yml` в репозитории — утечка при первом же форке/скриншоте. Секреты — через переменные окружения (`${DB_PASSWORD}`), Vault или k8s Secrets; в репо — только плейсхолдеры.
+
+8. **Stateful там, где нужен stateless.** Хранение пользовательского прогресса в `HttpSession` или в статической мапе в heap ломается ровно тогда, когда сервис масштабируют на 2+ пода: запрос уходит на другой инстанс, где состояния нет. Для REST — `SessionCreationPolicy.STATELESS`, состояние в токене или во внешнем хранилище (Redis/БД).
+
+## Практическая задача
+
+**Контекст.** Ты пилишь сервис управления складскими поставками (supply). Фронт-склад и мобильное приложение курьера будут ходить в твой HTTP-API. Нужен предсказуемый REST-контракт с валидацией, стандартными ошибками, пагинацией и безопасным ретраем создания.
+
+**Дано.**
+- Пустой Spring Boot 3.x проект (Java 21, PostgreSQL, Spring Web, Spring Data JPA, Validation, Security).
+- Доменная сущность `Supply` со статусами `DRAFT → SUBMITTED → ACCEPTED → REJECTED` и полями: `id`, `warehouseCode` (строка, обяз.), `itemsCount` (int > 0), `status`, `createdAt`, `version`.
+
+**ТЗ. Реализуй ресурс `/api/v1/supplies` с эндпоинтами:**
+1. `POST /api/v1/supplies` — создать поставку в статусе `DRAFT`. Тело: `warehouseCode`, `itemsCount`. Валидация обязательна. Ответ — `201 Created` с `Location`.
+2. `GET /api/v1/supplies/{id}` — получить одну; несуществующая — `404` в формате ProblemDetail.
+3. `GET /api/v1/supplies?status=SUBMITTED&page=0&size=20` — список с фильтром по статусу и offset-пагинацией; в ответе — `content`, `page`, `size`, `totalElements`.
+4. `POST /api/v1/supplies/{id}/submission` — перевести `DRAFT → SUBMITTED`. Повторный вызов на уже `SUBMITTED`/`ACCEPTED`/`REJECTED` — `409 Conflict` (ProblemDetail), состояние не меняется.
+5. Создание должно быть **идемпотентным по ретраю**: клиент шлёт заголовок `Idempotency-Key: <uuid>`; повтор с тем же ключом в течение окна не создаёт вторую поставку, а возвращает результат первого запроса (тот же `id`, статус `200`/`201`).
+
+**Критерии приёмки.**
+- Контроллер тонкий: без бизнес-логики и без прямого доступа к репозиторию (только через сервис).
+- Наружу не уходит JPA-сущность — только DTO (`record`).
+- Валидация через `@Valid`; на `400` тело — ProblemDetail c разбором по полям.
+- Все ошибки идут через один `@RestControllerAdvice`, в теле — `application/problem+json`.
+- `POST` дважды с одним `Idempotency-Key` → в БД одна строка `Supply`; с разными ключами → две.
+- Смена статуса защищена от гонки (два параллельных `submission` не приведут к рассогласованию) — подумай про `@Version`.
+- Security-конфиг — stateless (`SessionCreationPolicy.STATELESS`), никакого `WebSecurityConfigurerAdapter`.
+
+**Подсказки (без готового решения).**
+- Идемпотентность: заведи таблицу `idempotency_key (key PK, supply_id, created_at)`. В одной транзакции с созданием поставки вставляй ключ; при конфликте уникальности (`ON CONFLICT DO NOTHING` / `DataIntegrityViolationException`) — прочитай уже сохранённый результат по ключу и верни его. Продумай окно жизни ключей (TTL-очистка). Про паттерн и гонки — раздел роадмапа «Надёжность и архитектура».
+- Смена статуса — доменным методом `supply.submit()` с проверкой текущего статуса внутри, а не `if` в контроллере/сервисе.
+- Для `409` заведи доменное исключение и отдельный `@ExceptionHandler`, возвращающий `ProblemDetail.forStatusAndDetail(HttpStatus.CONFLICT, ...)`.
+- Не отдавай `Page<Supply>` напрямую — оберни в свой `PageResponse<SupplyResponse>`.
+- Проверь глазами: `curl -i` на каждый эндпоинт — код, `Location`, `Content-Type: application/problem+json` на ошибках.
+
+**Со звёздочкой.** Добавь оптимистичный `PATCH /api/v1/supplies/{id}` для правки `itemsCount` только в статусе `DRAFT`; в остальных статусах — `409`. Подумай, почему это `PATCH`, а не `PUT`, и идемпотентен ли он здесь.
+
+## Что почитать
+
+- **Spring Boot 3 — Web / REST (официальная дока):** https://docs.spring.io/spring-boot/reference/web/servlet.html — контроллеры, обработка ошибок, конфигурация MVC.
+- **Spring — Building a RESTful Web Service (guide):** https://spring.io/guides/gs/rest-service — канонический стартовый гайд по `@RestController`.
+- **Error Responses / ProblemDetail (Spring Framework docs):** https://docs.spring.io/spring-framework/reference/web/webmvc/mvc-ann-rest-exceptions.html — RFC 7807/9457 в Spring, `ResponseEntityExceptionHandler`.
+- **Spring Data JPA — Paging and Sorting:** https://docs.spring.io/spring-data/jpa/reference/repositories/query-methods-details.html — `Pageable`, `Page`/`Slice`, сортировка.
+- **RFC 9457 — Problem Details for HTTP APIs:** https://www.rfc-editor.org/rfc/rfc9457 — первоисточник формата ошибок (обновляет RFC 7807).

--- a/src/main/resources/other/spring/spring-boot.md
+++ b/src/main/resources/other/spring/spring-boot.md
@@ -1,0 +1,561 @@
+# Spring Boot 3
+
+## Зачем это нужно / какую проблему решает
+
+Представь: тебе поручили поднять простейший REST-сервис — принять HTTP-запрос, сходить в PostgreSQL, вернуть JSON. На «голом» Spring это выглядит так: подключаешь десяток jar-ов (spring-web, spring-webmvc, jackson, hibernate, hikari, драйвер БД) и вручную следишь, чтобы их версии не конфликтовали. Потом руками поднимаешь `DispatcherServlet`, регистрируешь `ViewResolver`, настраиваешь `DataSource`, создаёшь `EntityManagerFactory`, `TransactionManager`, оборачиваешь всё в `web.xml` и пачку XML-конфигов. Разворачиваешь `.war` в отдельно установленный Tomcat. День работы — и это ещё до первой строчки бизнес-логики.
+
+Проблема одним словом — **boilerplate**: горы инфраструктурного кода и конфигурации, которые в 99% проектов одинаковы, но которые надо каждый раз писать заново и держать согласованными.
+
+Spring Boot переворачивает подход: **convention over configuration**. Ты объявляешь *что* тебе нужно (стартер `spring-boot-starter-web` — «хочу веб»), а Boot сам решает *как* это собрать: подтягивает согласованный набор зависимостей, поднимает встроенный Tomcat, настраивает Jackson, `DataSource`, транзакции — всё с разумными дефолтами, которые ты переопределяешь только там, где реально надо. Приложение — это обычный `main()`, который запускается как `java -jar app.jar`. Никакого внешнего сервера приложений, никакого `web.xml`.
+
+Результат: рабочий сервис поднимается за 15 минут, а ты сразу пишешь бизнес-логику, а не воюешь с инфраструктурой.
+
+**Что важно про версию 3.x.** Spring Boot 3 — это водораздел:
+- **Java 17+ обязательна** (Boot 3.2+ полноценно дружит с Java 21 — виртуальные потоки, records, pattern matching). Мы на Java 21.
+- **javax → jakarta.** Вся Java EE переехала в Eclipse Foundation и сменила пакеты: `javax.persistence.*` → `jakarta.persistence.*`, `javax.validation.*` → `jakarta.validation.*`, `javax.servlet.*` → `jakarta.servlet.*`. Старые библиотеки с `javax` в Boot 3 **не заведутся**. Это первое, обо что спотыкаются при миграции.
+- Hibernate 6, Spring Framework 6, Spring Security 6 (без `WebSecurityConfigurerAdapter`), поддержка нативной компиляции через GraalVM.
+
+## Ключевые понятия
+
+### Стартеры (starters)
+
+Стартер — это «мета-зависимость»: пустой по коду артефакт, который тянет за собой согласованный набор библиотек под конкретную задачу. `spring-boot-starter-web` = Spring MVC + встроенный Tomcat + Jackson. `spring-boot-starter-data-jpa` = Spring Data JPA + Hibernate + HikariCP. Тебе не нужно подбирать версии руками — их фиксирует **BOM** (Bill of Materials) родительского `spring-boot-starter-parent` или `spring-boot-dependencies`. Ты пишешь зависимость без версии, версию проставляет Boot.
+
+### Автоконфигурация (auto-configuration)
+
+Сердце Boot. При старте Boot сканирует classpath и применяет сотни `@AutoConfiguration`-классов по принципу **условной регистрации бинов**: `@ConditionalOnClass` (если класс есть в classpath), `@ConditionalOnMissingBean` (если ты сам такой бин не объявил), `@ConditionalOnProperty` и т.д.
+
+Логика простая: «вижу в classpath `DataSource` и драйвер PostgreSQL, а своего бина `DataSource` пользователь не создал — создам его сам из `spring.datasource.*`». Ключевой принцип — **твой бин всегда побеждает**: как только ты объявляешь свой `@Bean`, автоконфигурация отступает (`@ConditionalOnMissingBean`). Автоконфигурация — это разумные дефолты, а не клетка.
+
+Хочешь увидеть, что именно применилось и почему — запусти с `--debug`, Boot напечатает **condition evaluation report**: positive/negative matches.
+
+### Embedded-сервер
+
+В Boot HTTP-сервер (по умолчанию Tomcat) встроен **внутрь** приложения как обычная библиотека. Артефакт — исполняемый «fat jar» со всеми зависимостями внутри. Деплой — это `java -jar app.jar`, а не «установи Tomcat и положи туда war». Это фундамент для контейнеризации: один jar = один Docker-образ = один процесс. Хочешь Jetty или Undertow вместо Tomcat — исключаешь стартер Tomcat и подключаешь другой.
+
+### `@SpringBootApplication`
+
+Одна аннотация на главном классе, объединяющая три:
+- `@SpringBootConfiguration` — класс является источником бин-определений (`@Configuration`).
+- `@EnableAutoConfiguration` — включить автоконфигурацию.
+- `@ComponentScan` — сканировать пакет этого класса и вложенные на предмет `@Component`/`@Service`/`@Repository`/`@RestController`.
+
+Отсюда важное правило: **главный класс кладут в корневой пакет проекта**, чтобы component scan увидел все нижележащие пакеты. Бины из пакета *выше или сбоку* не подхватятся.
+
+### `application.yml` и внешняя конфигурация
+
+Настройки живут вне кода — в `application.yml` (или `.properties`). Boot читает их из чётко определённой цепочки источников с приоритетами: аргументы командной строки > переменные окружения > `application-{profile}.yml` > `application.yml`. Это позволяет один и тот же jar гонять в dev/stage/prod, меняя только окружение.
+
+**Профили** (`spring.profiles.active=prod`) подключают профильные файлы `application-prod.yml`. **Секреты** (пароли, токены) в yml **не хранят** — их подставляют через переменные окружения: `${DB_PASSWORD}`.
+
+Типобезопасный доступ к настройкам — `@ConfigurationProperties`, который маппит ветку yml на Java-record.
+
+### Слои: controller → service → repository
+
+Стандартная трёхслойная архитектура, которую Boot поддерживает стереотипными аннотациями:
+
+- **`@RestController`** — веб-слой. Принимает HTTP-запрос, валидирует вход, делегирует сервису, отдаёт ответ/статус. Тонкий: никакой бизнес-логики.
+- **`@Service`** — бизнес-логика и границы транзакций (`@Transactional`). Оркестрирует репозитории.
+- **`@Repository`** — доступ к данным. С Spring Data JPA — это интерфейс поверх `JpaRepository`, реализацию генерирует фреймворк.
+
+Зависимости идут строго вниз: controller → service → repository. Контроллер не лезет в репозиторий напрямую. (В нашем роадмапе этому посвящён раздел «Слоистая архитектура» — здесь только фундамент.)
+
+### Внедрение зависимостей (DI)
+
+Boot — это IoC-контейнер: он создаёт бины и связывает их. Правильный способ — **конструкторная инъекция**: зависимости приходят в конструктор, поле объявляется `final`. Для класса с одним конструктором `@Autowired` не нужен, а Lombok `@RequiredArgsConstructor` генерирует конструктор по `final`-полям. Полевая инъекция (`@Autowired` на поле) — антипаттерн (см. «Подводные камни»).
+
+### Actuator
+
+`spring-boot-starter-actuator` добавляет production-ready эндпоинты для эксплуатации: `/actuator/health` (liveness/readiness для k8s), `/actuator/metrics` и `/actuator/prometheus` (метрики через Micrometer), `/actuator/info`, `/actuator/env`. По умолчанию по HTTP наружу торчит только `health` — остальное включают явно, потому что среди них есть чувствительные (`env`, `heapdump`).
+
+### DevTools
+
+`spring-boot-devtools` — инструмент для *локальной разработки*: автоперезапуск приложения при изменении classpath (быстрее полного рестарта за счёт двух класслоадеров), отключение кешей шаблонов, LiveReload. В prod-сборку не попадает (Boot сам исключает его из fat jar). Никогда не тащи devtools в продакшн.
+
+## Примеры на Java
+
+Соберём минимальный, но реалистичный сервис: сущность `Order`, репозиторий, сервис с транзакциями, REST-контроллер с валидацией, конфиг и типобезопасные настройки.
+
+### Зависимости (Maven)
+
+```xml
+<parent>
+    <groupId>org.springframework.boot</groupId>
+    <artifactId>spring-boot-starter-parent</artifactId>
+    <version>3.4.1</version> <!-- версии дочерних зависимостей фиксирует этот BOM -->
+</parent>
+
+<properties>
+    <java.version>21</java.version>
+</properties>
+
+<dependencies>
+    <!-- Web: Spring MVC + встроенный Tomcat + Jackson -->
+    <dependency>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-web</artifactId>
+    </dependency>
+    <!-- Data JPA: Spring Data + Hibernate 6 + HikariCP -->
+    <dependency>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-data-jpa</artifactId>
+    </dependency>
+    <!-- Bean Validation (jakarta.validation) -->
+    <dependency>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-validation</artifactId>
+    </dependency>
+    <!-- Production-ready эндпоинты -->
+    <dependency>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-actuator</artifactId>
+    </dependency>
+    <!-- Драйвер PostgreSQL (версия из BOM) -->
+    <dependency>
+        <groupId>org.postgresql</groupId>
+        <artifactId>postgresql</artifactId>
+        <scope>runtime</scope>
+    </dependency>
+    <!-- Только для локальной разработки; в fat jar не попадёт -->
+    <dependency>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-devtools</artifactId>
+        <scope>runtime</scope>
+        <optional>true</optional>
+    </dependency>
+</dependencies>
+```
+
+### Главный класс
+
+```java
+package com.example.shop; // корневой пакет — component scan увидит всё ниже
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication // = @SpringBootConfiguration + @EnableAutoConfiguration + @ComponentScan
+public class ShopApplication {
+    public static void main(String[] args) {
+        SpringApplication.run(ShopApplication.class, args);
+    }
+}
+```
+
+### Сущность (jakarta.persistence — НЕ javax)
+
+```java
+package com.example.shop.order;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.math.BigDecimal;
+import java.time.Instant;
+
+@Entity
+@Table(name = "orders")
+public class Order {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String customerEmail;
+
+    @Column(nullable = false)
+    private BigDecimal amount;
+
+    @Enumerated(EnumType.STRING) // хранить как текст 'NEW', а не как ordinal 0 (см. подводные камни)
+    @Column(nullable = false)
+    private OrderStatus status;
+
+    @Column(nullable = false, updatable = false)
+    private Instant createdAt;
+
+    protected Order() {
+        // требуется JPA
+    }
+
+    public Order(String customerEmail, BigDecimal amount) {
+        this.customerEmail = customerEmail;
+        this.amount = amount;
+        this.status = OrderStatus.NEW;
+        this.createdAt = Instant.now();
+    }
+
+    // Меняем состояние осмысленным методом, а не публичным сеттером статуса
+    public void markPaid() {
+        if (status != OrderStatus.NEW) {
+            throw new IllegalStateException("Оплатить можно только новый заказ, текущий статус: " + status);
+        }
+        this.status = OrderStatus.PAID;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public String getCustomerEmail() {
+        return customerEmail;
+    }
+
+    public BigDecimal getAmount() {
+        return amount;
+    }
+
+    public OrderStatus getStatus() {
+        return status;
+    }
+
+    public Instant getCreatedAt() {
+        return createdAt;
+    }
+}
+```
+
+```java
+package com.example.shop.order;
+
+public enum OrderStatus {
+    NEW, PAID, CANCELLED
+}
+```
+
+### Репозиторий (Spring Data JPA)
+
+```java
+package com.example.shop.order;
+
+import java.util.List;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+// Реализацию генерирует Spring Data — писать её руками не нужно
+public interface OrderRepository extends JpaRepository<Order, Long> {
+
+    // Query-метод: имя метода → SQL. Никакого тела.
+    List<Order> findByStatus(OrderStatus status);
+
+    Optional<Order> findByCustomerEmailAndStatus(String email, OrderStatus status);
+}
+```
+
+### DTO на records (Java 21) с валидацией (jakarta.validation)
+
+```java
+package com.example.shop.order;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+import java.math.BigDecimal;
+import java.time.Instant;
+
+public record CreateOrderRequest(
+        @NotNull @Email String customerEmail,
+        @NotNull @Positive BigDecimal amount
+) {}
+
+public record OrderResponse(
+        Long id,
+        String customerEmail,
+        BigDecimal amount,
+        OrderStatus status,
+        Instant createdAt
+) {
+    static OrderResponse from(Order order) {
+        return new OrderResponse(
+                order.getId(),
+                order.getCustomerEmail(),
+                order.getAmount(),
+                order.getStatus(),
+                order.getCreatedAt()
+        );
+    }
+}
+```
+
+### Сервис (бизнес-логика + транзакции)
+
+```java
+package com.example.shop.order;
+
+import java.util.List;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class OrderService {
+
+    private final OrderRepository orderRepository;
+
+    // Конструкторная инъекция: @Autowired не нужен для единственного конструктора
+    public OrderService(OrderRepository orderRepository) {
+        this.orderRepository = orderRepository;
+    }
+
+    @Transactional // пишущая операция — открываем транзакцию
+    public OrderResponse create(CreateOrderRequest request) {
+        var order = new Order(request.customerEmail(), request.amount());
+        var saved = orderRepository.save(order);
+        return OrderResponse.from(saved);
+    }
+
+    @Transactional
+    public OrderResponse pay(Long orderId) {
+        var order = orderRepository.findById(orderId)
+                .orElseThrow(() -> new OrderNotFoundException(orderId));
+        order.markPaid(); // dirty checking: Hibernate сам сделает UPDATE на коммите
+        return OrderResponse.from(order);
+    }
+
+    @Transactional(readOnly = true) // для чтения — оптимизация, без dirty checking
+    public List<OrderResponse> findByStatus(OrderStatus status) {
+        return orderRepository.findByStatus(status).stream()
+                .map(OrderResponse::from)
+                .toList();
+    }
+}
+```
+
+```java
+package com.example.shop.order;
+
+public class OrderNotFoundException extends RuntimeException {
+    public OrderNotFoundException(Long id) {
+        super("Заказ не найден: " + id);
+    }
+}
+```
+
+### REST-контроллер (тонкий)
+
+```java
+package com.example.shop.order;
+
+import jakarta.validation.Valid;
+import java.util.List;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/orders")
+public class OrderController {
+
+    private final OrderService orderService;
+
+    public OrderController(OrderService orderService) {
+        this.orderService = orderService;
+    }
+
+    @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
+    public OrderResponse create(@Valid @RequestBody CreateOrderRequest request) {
+        return orderService.create(request); // делегируем и всё
+    }
+
+    @PostMapping("/{id}/pay")
+    public OrderResponse pay(@PathVariable Long id) {
+        return orderService.pay(id);
+    }
+
+    @GetMapping
+    public List<OrderResponse> list(@RequestParam OrderStatus status) {
+        return orderService.findByStatus(status);
+    }
+}
+```
+
+### Глобальная обработка ошибок
+
+```java
+package com.example.shop.order;
+
+import java.time.Instant;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ProblemDetail;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class ApiExceptionHandler {
+
+    // ProblemDetail (RFC 7807) — стандарт из Spring 6, отдельная библиотека не нужна
+    @ExceptionHandler(OrderNotFoundException.class)
+    public ProblemDetail handleNotFound(OrderNotFoundException ex) {
+        var problem = ProblemDetail.forStatusAndDetail(HttpStatus.NOT_FOUND, ex.getMessage());
+        problem.setProperty("timestamp", Instant.now());
+        return problem;
+    }
+
+    @ExceptionHandler(IllegalStateException.class)
+    public ProblemDetail handleConflict(IllegalStateException ex) {
+        return ProblemDetail.forStatusAndDetail(HttpStatus.CONFLICT, ex.getMessage());
+    }
+}
+```
+
+### Типобезопасная конфигурация
+
+```java
+package com.example.shop.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+// Маппит ветку shop.* из application.yml на immutable-record
+@ConfigurationProperties(prefix = "shop")
+public record ShopProperties(
+        int maxOrdersPerCustomer,
+        String supportEmail
+) {}
+```
+
+```java
+package com.example.shop.config;
+
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@EnableConfigurationProperties(ShopProperties.class) // регистрируем properties-бин
+public class AppConfig {
+}
+```
+
+### application.yml
+
+```yaml
+spring:
+  application:
+    name: shop-service
+  datasource:
+    url: jdbc:postgresql://localhost:5432/shop
+    username: shop
+    # Секрет — из переменной окружения, НЕ хардкодим в файл
+    password: ${DB_PASSWORD}
+  jpa:
+    hibernate:
+      ddl-auto: validate   # в prod — validate/none; схемой рулит Liquibase/Flyway, не Hibernate
+    properties:
+      hibernate:
+        jdbc:
+          batch_size: 50
+    open-in-view: false     # отключаем OSIV: транзакции — только в сервисе (см. подводные камни)
+
+# Наши типобезопасные настройки
+shop:
+  max-orders-per-customer: 100
+  support-email: support@example.com
+
+# Actuator: наружу — только health + prometheus, ничего лишнего
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health, info, prometheus
+  endpoint:
+    health:
+      probes:
+        enabled: true   # /health/liveness и /health/readiness для Kubernetes
+```
+
+```yaml
+# application-prod.yml — подключится при spring.profiles.active=prod
+spring:
+  jpa:
+    hibernate:
+      ddl-auto: validate
+logging:
+  level:
+    root: INFO
+    com.example.shop: INFO
+```
+
+## Частые ошибки / подводные камни
+
+### 1. Полевая инъекция вместо конструкторной
+
+`@Autowired private OrderRepository repo;` — антипаттерн. Поле нельзя сделать `final`, класс невозможно инстанцировать без Spring-контейнера (мешает тестам), скрытые зависимости легко разрастаются до «God-класса», а инъекция происходит после конструктора — в самом конструкторе зависимость ещё `null`. **Правильно:** конструкторная инъекция с `final`-полями (или Lombok `@RequiredArgsConstructor`). Тогда объект всегда в консистентном состоянии, а обязательность зависимости проверяется компилятором.
+
+### 2. `@Transactional` на private-методе или self-invocation
+
+`@Transactional` работает через Spring AOP-прокси. Прокси перехватывает только **внешние** вызовы через бин. Поэтому:
+- на `private`/`protected`/package-private методе аннотация **не работает** — прокси не может его обернуть;
+- вызов `this.otherMethod()` внутри того же класса идёт мимо прокси — транзакция/`@Cacheable`/`@Async` **не сработают**, даже если метод public.
+
+**Правильно:** транзакционный метод — `public`, и вызывается через *другой* бин (или через self-инъекцию/`TransactionTemplate`). Классическая ловушка: «поставил `@Transactional`, а откат не происходит» — почти всегда это self-invocation.
+
+### 3. N+1 запросов из-за ленивой загрузки
+
+`@OneToMany`/`@ManyToOne` по умолчанию (для `@OneToMany` — LAZY) при обходе коллекции в цикле стреляет отдельным SELECT на каждую сущность: 1 запрос на список + N на связи. На проде это кладёт БД. **Правильно:** осознанно грузить связи — `JOIN FETCH` в JPQL, `@EntityGraph` на методе репозитория, или `@BatchSize` для батч-подгрузки. И включи `spring.jpa.show-sql` / p6spy локально, чтобы *видеть* реальные запросы.
+
+### 4. `FetchType.EAGER` на всех связях «чтобы не падало»
+
+Обратная крайность: навешать `EAGER` везды, чтобы не ловить `LazyInitializationException`. Тогда любой запрос к сущности тащит за собой весь граф связанных данных — по десятку JOIN-ов на ровном месте, даже когда связи не нужны. **Правильно:** оставлять LAZY по умолчанию, а нужные связи подгружать точечно через fetch-join/entity-graph под конкретный сценарий. `LazyInitializationException` лечится границей транзакции в сервисе (и `open-in-view: false`), а не глобальным EAGER.
+
+### 5. Секреты прямо в `application.yml` и коммит в git
+
+`password: super-secret-123` в yml, закоммиченный в репозиторий — утечка, которую потом не вычистить из истории. **Правильно:** секреты — через переменные окружения (`${DB_PASSWORD}`), Vault, Kubernetes Secrets или Spring Cloud Config. В yml остаётся только placeholder. Плюс профили: `application-local.yml` для локалки (в `.gitignore`), прод-секреты — из окружения.
+
+### 6. `open-in-view` включён по умолчанию (OSIV)
+
+Boot по умолчанию держит `spring.jpa.open-in-view=true`: Hibernate-сессия живёт до конца обработки HTTP-запроса, включая рендеринг ответа. Это маскирует N+1 (ленивые связи «внезапно» подгружаются во View-слое) и держит соединение с БД занятым дольше нужного — под нагрузкой пул исчерпывается. **Правильно:** `open-in-view: false` и явно грузить всё нужное внутри транзакции сервиса. Boot даже пишет warning при старте, если OSIV включён неявно — не игнорируй его.
+
+### 7. Stateful-бин там, где нужен stateless
+
+Синглтон-бин (а `@Service`/`@Controller` по умолчанию синглтоны) с изменяемым полем-состоянием (`private List<Order> currentBatch`) — гонка данных: один экземпляр обслуживает все параллельные запросы разными потоками. **Правильно:** сервисы держать stateless, состояние передавать через параметры/локальные переменные метода. Идемпотентность, ретраи, rate limiting — это отдельные механизмы (см. раздел роадмапа «Надёжность и архитектура»), а не поля в синглтоне.
+
+## Практическая задача
+
+**Контекст.** Ты пишешь сервис бронирования переговорок (`meeting-room-service`). Нужен REST-эндпоинт создания брони. Ключевое требование бизнеса: **на одну переговорку в один временной слот не может быть двух подтверждённых броней** — иначе два отдела приходят в одну комнату.
+
+**Дано.**
+- Пустой Spring Boot 3.4 проект (Java 21), PostgreSQL поднят через docker-compose.
+- Стартеры: `web`, `data-jpa`, `validation`, `actuator`, драйвер postgres.
+- Сущность `Booking` (поля: `id`, `roomId: Long`, `slotStart: Instant`, `slotEnd: Instant`, `bookedBy: String`, `status: BookingStatus {ACTIVE, CANCELLED}`) — часть полей нужно спроектировать самому.
+
+**ТЗ.**
+1. Слои `controller → service → repository`. Контроллер тонкий, вся логика — в сервисе.
+2. `POST /api/v1/bookings` принимает JSON (`roomId`, `slotStart`, `slotEnd`, `bookedBy`), валидирует его через `jakarta.validation` (все поля обязательны, `slotEnd` позже `slotStart` — реализуй кастомную или составную проверку), возвращает `201 Created` с телом брони.
+3. Если на пересекающийся слот той же комнаты уже есть **ACTIVE**-бронь — вернуть `409 Conflict` с телом `ProblemDetail` и внятным сообщением.
+4. `GET /api/v1/bookings?roomId={id}` — список активных броней комнаты, отсортированных по `slotStart`.
+5. `DELETE /api/v1/bookings/{id}` — перевести бронь в `CANCELLED` (не удалять физически), `204 No Content`.
+6. Настройки: лимит `booking.max-active-per-user` (типобезопасный `@ConfigurationProperties`-record). При попытке создать бронь сверх лимита активных на пользователя — `422 Unprocessable Entity`.
+7. `application.yml`: `open-in-view: false`, `ddl-auto: validate`, пароль БД — из переменной окружения. Actuator наружу — только `health` и `prometheus`.
+
+**Критерии приёмки.**
+- Приложение стартует `java -jar`; `/actuator/health` отдаёт `UP`.
+- Все импорты — `jakarta.*`, ни одного `javax.*`.
+- Конструкторная инъекция везде, `@Transactional` — на public-методах сервиса, вызываемых через бин.
+- Дублирующая бронь на пересекающийся слот реально возвращает `409` (проверь двумя POST-запросами подряд).
+- В логах при создании брони видно **не больше ожидаемого** числа SQL-запросов (нет N+1 при выборке пересечений).
+- Секрет БД отсутствует в репозитории в открытом виде.
+
+**Подсказки (без готового решения).**
+- Пересечение интервалов: два отрезка `[a1,a2)` и `[b1,b2)` пересекаются, когда `a1 < b2 && b1 < a2`. Это ложится в один query-метод репозитория (`existsBy...` с двумя условиями по времени и `status = ACTIVE`) — не тащи все брони в память.
+- Гонка «два одновременных POST на один слот» query-методом до конца не закрывается: рядом с проверкой имеет смысл **уникальный частичный индекс** в БД (`UNIQUE ... WHERE status = 'ACTIVE'`) и обработка `DataIntegrityViolationException` → `409`. Продумай оба уровня защиты — это тема идемпотентности/надёжности из соответствующего раздела роадмапа.
+- Кастомная валидация «`slotEnd` > `slotStart`» — либо аннотация класс-уровня (`@AssertTrue`-метод на record), либо свой `ConstraintValidator`.
+- Разные бизнес-ошибки — разные статусы: маппинг исключений на HTTP делай в `@RestControllerAdvice` через `ProblemDetail`, а не `try/catch` в контроллере.
+- Не забудь `protected`-конструктор без аргументов в JPA-сущности и `@Enumerated(EnumType.STRING)` для статуса.
+
+## Что почитать
+
+- [Spring Boot 3 — официальная документация](https://docs.spring.io/spring-boot/index.html) — reference guide: автоконфигурация, external config, actuator.
+- [Guide: Building a RESTful Web Service (spring.io)](https://spring.io/guides/gs/rest-service) — канонический getting-started от Spring.
+- [Spring Boot 3.0 Migration Guide (javax → jakarta)](https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-3.0-Migration-Guide) — что ломается при переходе на Boot 3 и как чинить.
+- [Spring Data JPA — Reference](https://docs.spring.io/spring-data/jpa/reference/index.html) — query-методы, `@EntityGraph`, деривация запросов из имён.
+- [Baeldung: The @ConfigurationProperties Guide](https://www.baeldung.com/configuration-properties-in-spring-boot) — типобезопасная конфигурация на практике.

--- a/src/main/resources/other/spring/spring-cloud.md
+++ b/src/main/resources/other/spring/spring-cloud.md
@@ -1,0 +1,529 @@
+# Spring Cloud (микросервисы)
+
+> Стек урока: **Java 21, Spring Boot 3.x (Jakarta EE), PostgreSQL**. Всё, что ниже — про Spring Boot 3 и Spring Cloud 2023.x+ (BOM-версии, которые совместимы с Boot 3). Никаких `javax.*`, `WebSecurityConfigurerAdapter` и XML-контекстов.
+
+Это **обзорный** урок. Цель — не научить вас поднимать 12 сервисов, а научить понимать, *из чего* состоит распределённая система на Spring, *какую цену* вы за это платите и, главное, **когда всё это НЕ нужно**. Микросервисы — не апгрейд монолита, а размен: вы меняете простоту внутрипроцессного вызова на операционную сложность сети. Разберёмся, за что именно.
+
+---
+
+## Зачем это нужно / какую проблему решает
+
+Представьте: вы — команда из 40 разработчиков на одном большом монолите `shop-backend`. Всё началось хорошо, но сейчас:
+
+- **Деплой — это событие.** Чтобы выкатить правку в модуль «отзывы», вы пересобираете и передеплоиваете весь монолит вместе с оплатой, каталогом и складом. Одна команда блокирует пять других. Релиз-поезд ходит раз в неделю, и все на него опаздывают.
+- **Масштабируется всё сразу.** В «чёрную пятницу» нагрузка растёт на *поиск* и *корзину*, но масштабировать вы вынуждены весь монолит целиком — 8 ГБ heap в каждой реплике, включая никому не нужный в пике модуль «бухгалтерская выгрузка».
+- **Падение в одном месте кладёт всё.** Утечка памяти в редко используемом отчёте роняет процесс — и вместе с ним оплату.
+- **Технологический замок.** Хотите переписать поиск на другой стек или обновить мажор библиотеки — нельзя, всё в одном classpath.
+
+Микросервисный подход отвечает: **разрежьте систему по бизнес-границам** (`payment-service`, `catalog-service`, `order-service`), дайте каждой команде свой деплой, своё масштабирование, свою БД. Теперь «отзывы» катятся 20 раз в день и никого не трогают, а поиск масштабируется отдельно.
+
+Но как только вы разрезали монолит на процессы, общающиеся по сети, вылезает **новый класс проблем**, которых в монолите не было в принципе:
+
+| Проблема | В монолите | В микросервисах |
+|---|---|---|
+| Найти другой модуль | `@Autowired` — и он тут | Где сейчас живёт `payment-service`? На каком хосте, каком порту, сколько реплик? → **Service Discovery** |
+| Конфигурация | один `application.yml` | 15 сервисов × 4 окружения = хаос → **Config Server** |
+| Внешний вход | один порт | 15 портов, где auth, CORS, rate limit? → **API Gateway** |
+| Вызов другого модуля | вызов метода, всегда успешен | сетевой вызов, который **упадёт**, зависнет, вернёт 500 → **OpenFeign + Resilience4j** |
+| «Почему запрос тормозит?» | один стектрейс | запрос прошёл через 6 сервисов — где потерялись 800 мс? → **распределённая трассировка** |
+
+**Spring Cloud** — это набор стартеров, которые дают готовые решения для каждой из этих проблем, интегрированные в привычную модель Spring Boot. Именно их мы и разбираем.
+
+> **Главная мысль урока, которую держите в голове до самого конца:** каждый пункт правой колонки — это код, инфраструктура и режимы отказа, которых у вас *не было*. Микросервисы решают организационные и масштабные проблемы ценой инженерной сложности. Если у вас нет этих проблем — вы платите цену впустую. К вопросу «когда НЕ нужно» вернёмся в конце.
+
+---
+
+## Ключевые понятия
+
+### Config Server — централизованная конфигурация
+
+Проблема: 15 сервисов, у каждого свои `application.yml`, и в каждом — адрес БД, таймауты, фичефлаги, которые различаются между `dev`/`stage`/`prod`. Хранить это в 15 репозиториях и синхронизировать вручную — боль. Менять таймаут в проде — пересобирать образ.
+
+**Spring Cloud Config Server** — отдельный сервис, который отдаёт конфигурацию по HTTP. Конфиги лежат в одном месте (обычно Git-репозиторий), а клиенты при старте (или по сигналу `refresh`) забирают свою часть.
+
+- Клиент запрашивает `{имя-приложения}/{профиль}` → сервер отдаёт слитый набор `application.yml` (общий) + `order-service-prod.yml` (специфичный).
+- Секреты шифруются (`{cipher}...`), а лучше — вообще не в Config Server, а в Vault (Spring Cloud Config поддерживает Vault-backend).
+- Git как бэкенд = вся история изменений конфига под ревью и откатом.
+
+> В облачных стеках (Kubernetes) эту роль часто берут `ConfigMap`/`Secret` + внешний секрет-менеджер, а Config Server не поднимают. Это нормально — Spring Cloud не обязателен, если платформа уже решает задачу.
+
+### Service Discovery — «где живёт сервис?»
+
+В монолите зависимость — это бин. В сети — это IP:порт, который **меняется**: реплики поднимаются и гаснут (автоскейл, рестарты, падения). Хардкодить адреса нельзя.
+
+**Service Discovery** — это реестр: сервисы при старте *регистрируются* («я `payment-service`, я на `10.0.3.7:8081`, я жив»), а клиенты *спрашивают* реестр по логическому имени. Классика в мире Spring — **Netflix Eureka** (`spring-cloud-starter-netflix-eureka-server` / `-client`). Клиент шлёт heartbeat; перестал слать — его выкидывают из реестра.
+
+Поверх этого работает **клиентская балансировка** (`spring-cloud-loadbalancer`): клиент получает *список* инстансов `payment-service` и сам выбирает, к кому пойти (round-robin и т.п.), — без отдельного L7-балансировщика на каждый вызов.
+
+> В Kubernetes discovery обычно уже встроен: `Service` даёт стабильное DNS-имя и балансировку из коробки. Тогда Eureka не нужна — вы зовёте `http://payment-service/...`, а k8s разрулит. Это ещё один пример, где Spring Cloud-компонент вытесняется платформой.
+
+### API Gateway — единая точка входа
+
+15 сервисов = 15 адресов. Наружу так выставлять нельзя: где централизованно проверять JWT, резать CORS, ставить rate limit, маршрутизировать `/api/orders/**` → `order-service`?
+
+**Spring Cloud Gateway** — реактивный (на Spring WebFlux) шлюз. Он:
+- **маршрутизирует** по предикатам (path, header, method) на нужный сервис (можно через discovery: `lb://order-service`);
+- прогоняет запрос через **фильтры** — аутентификация, добавление/удаление заголовков, retry, circuit breaker, rate limiting;
+- даёт клиенту *один* стабильный адрес, скрывая внутреннюю топологию.
+
+Rate limiting, идемпотентность на входе, ретраи — это уже территория раздела **«Надёжность и архитектура»** роадмапа; Gateway — удобное место, где эти паттерны применяются централизованно.
+
+### OpenFeign — межсервисные HTTP-вызовы декларативно
+
+Когда `order-service` должен спросить у `payment-service` статус оплаты, писать руками `RestClient`/`WebClient` с URL, сериализацией и обработкой ошибок — многословно. **Spring Cloud OpenFeign** позволяет описать вызов как **интерфейс с аннотациями**, а реализацию сгенерирует фреймворк:
+
+```java
+@FeignClient(name = "payment-service") // имя из discovery → балансировка автоматически
+public interface PaymentClient {
+    @GetMapping("/payments/{orderId}")
+    PaymentDto getByOrder(@PathVariable Long orderId);
+}
+```
+
+Вы инжектите `PaymentClient` как обычный бин и зовёте `getByOrder(...)` — под капотом HTTP-запрос, балансировка через discovery, сериализация. Feign легко оборачивается в Resilience4j (таймаут, circuit breaker, fallback).
+
+> Feign — блокирующий. Для реактивного/стримингового взаимодействия берут `WebClient`. Для простых синхронных вызовов между сервисами Feign — прагматичный дефолт.
+
+### Resilience4j — устойчивость к отказам
+
+Сетевой вызов **всегда может упасть**: таймаут, 503, недоступная реплика. Если `order-service` синхронно ждёт зависший `payment-service`, его потоки копятся, и он падает следом — **каскадный отказ**.
+
+**Resilience4j** даёт паттерны:
+- **Circuit Breaker** — «предохранитель»: после серии ошибок перестаёт долбить упавший сервис (open), даёт ему очухаться, периодически пробует (half-open).
+- **Retry** — повтор с backoff (только для **идемпотентных** операций!).
+- **TimeLimiter**, **Bulkhead**, **RateLimiter** — таймауты, изоляция пулов, ограничение частоты.
+
+Это большая тема со своими граблями (ретраи неидемпотентных операций, дублирование эффектов). Подробно — в разделе **«Надёжность и архитектура»** роадмапа (идемпотентность, ретраи, rate limiting). Здесь важно понять: **в распределённой системе устойчивость — не опция, а обязательная часть каждого межсервисного вызова.**
+
+### Распределённая трассировка — «где потерялись 800 мс?»
+
+Запрос от пользователя прошёл: Gateway → `order-service` → `payment-service` → `catalog-service`. Ответ пришёл за 1.2 с. Где узкое место? В монолите — один стектрейс; здесь — четыре разных лога на четырёх хостах, и связать их нечем.
+
+**Micrometer Tracing** (в Spring Boot 3 пришёл на смену Spring Cloud Sleuth) присваивает каждому входящему запросу **traceId**, а каждому шагу — **spanId**, и *пробрасывает* их между сервисами через HTTP-заголовки (W3C `traceparent`). Экспортёр (**Zipkin**, **Tempo**, Jaeger через OTLP) собирает спаны в единую «водопадную» диаграмму: видно, что 800 мс съел вызов `catalog-service`.
+
+`traceId` также попадает в MDC логов — по нему можно собрать логи *всех* сервисов по одному запросу. Без трассировки отлаживать распределённую систему практически невозможно.
+
+---
+
+## Примеры на Java
+
+Соберём минимальный, но реалистичный срез: `order-service` принимает заказ, сохраняет в PostgreSQL и синхронно спрашивает у `payment-service` статус оплаты через Feign, обёрнутый в circuit breaker.
+
+### 1. Зависимости (Maven)
+
+BOM Spring Cloud фиксирует совместимые версии всех стартеров — это единственный правильный способ подключать Spring Cloud.
+
+```xml
+<properties>
+    <spring-cloud.version>2023.0.3</spring-cloud.version> <!-- совместимо с Spring Boot 3.2/3.3 -->
+</properties>
+
+<dependencyManagement>
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework.cloud</groupId>
+            <artifactId>spring-cloud-dependencies</artifactId>
+            <version>${spring-cloud.version}</version>
+            <type>pom</type>
+            <scope>import</scope>
+        </dependency>
+    </dependencies>
+</dependencyManagement>
+
+<dependencies>
+    <!-- web + jpa + postgres -->
+    <dependency>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-web</artifactId>
+    </dependency>
+    <dependency>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-data-jpa</artifactId>
+    </dependency>
+    <dependency>
+        <groupId>org.postgresql</groupId>
+        <artifactId>postgresql</artifactId>
+        <scope>runtime</scope>
+    </dependency>
+
+    <!-- межсервисные вызовы -->
+    <dependency>
+        <groupId>org.springframework.cloud</groupId>
+        <artifactId>spring-cloud-starter-openfeign</artifactId>
+    </dependency>
+    <!-- устойчивость: circuit breaker на Resilience4j -->
+    <dependency>
+        <groupId>org.springframework.cloud</groupId>
+        <artifactId>spring-cloud-starter-circuitbreaker-resilience4j</artifactId>
+    </dependency>
+
+    <!-- распределённая трассировка: Micrometer + экспорт в Zipkin -->
+    <dependency>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-actuator</artifactId>
+    </dependency>
+    <dependency>
+        <groupId>io.micrometer</groupId>
+        <artifactId>micrometer-tracing-bridge-brave</artifactId>
+    </dependency>
+    <dependency>
+        <groupId>io.zipkin.reporter2</groupId>
+        <artifactId>zipkin-reporter-brave</artifactId>
+    </dependency>
+</dependencies>
+```
+
+### 2. Сущность и репозиторий (Jakarta, PostgreSQL)
+
+```java
+package com.example.order.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.math.BigDecimal;
+import java.time.Instant;
+
+@Entity
+@Table(name = "orders")
+public class Order {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private Long customerId;
+
+    @Column(nullable = false)
+    private BigDecimal amount;
+
+    @Enumerated(EnumType.STRING) // строкой, а не ordinal — не поедет при добавлении статуса
+    @Column(nullable = false)
+    private OrderStatus status;
+
+    @Column(nullable = false, updatable = false)
+    private Instant createdAt;
+
+    protected Order() { // для JPA
+    }
+
+    public Order(Long customerId, BigDecimal amount) {
+        this.customerId = customerId;
+        this.amount = amount;
+        this.status = OrderStatus.NEW;
+        this.createdAt = Instant.now();
+    }
+
+    // изменение состояния — через осмысленный метод, не через setStatus(...)
+    public void markPaid() {
+        if (this.status != OrderStatus.NEW) {
+            throw new IllegalStateException("Оплатить можно только новый заказ, текущий статус: " + status);
+        }
+        this.status = OrderStatus.PAID;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public OrderStatus getStatus() {
+        return status;
+    }
+
+    public BigDecimal getAmount() {
+        return amount;
+    }
+}
+```
+
+```java
+package com.example.order.domain;
+
+public enum OrderStatus {
+    NEW, PAID, CANCELLED
+}
+```
+
+```java
+package com.example.order.domain;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface OrderRepository extends JpaRepository<Order, Long> {
+}
+```
+
+### 3. Feign-клиент к payment-service с fallback
+
+```java
+package com.example.order.client;
+
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+
+// name = логическое имя сервиса (через discovery → клиентская балансировка).
+// fallback — что вернуть, если payment-service недоступен (сработал circuit breaker).
+@FeignClient(name = "payment-service", fallback = PaymentClientFallback.class)
+public interface PaymentClient {
+
+    @GetMapping("/payments/{orderId}")
+    PaymentDto getByOrder(@PathVariable Long orderId);
+}
+```
+
+```java
+package com.example.order.client;
+
+// record — иммутабельный DTO контракта между сервисами
+public record PaymentDto(Long orderId, String state) {
+}
+```
+
+```java
+package com.example.order.client;
+
+import org.springframework.stereotype.Component;
+
+// Деградация вместо падения: не знаем статус оплаты — считаем "неизвестно",
+// а не роняем весь запрос создания заказа.
+@Component
+public class PaymentClientFallback implements PaymentClient {
+
+    @Override
+    public PaymentDto getByOrder(Long orderId) {
+        return new PaymentDto(orderId, "UNKNOWN");
+    }
+}
+```
+
+Чтобы fallback заработал, включаем интеграцию Feign с circuit breaker (в `application.yml`):
+
+```yaml
+feign:
+  circuitbreaker:
+    enabled: true
+```
+
+### 4. Сервис — конструкторная инъекция, транзакция на public-методе бина
+
+```java
+package com.example.order.service;
+
+import com.example.order.client.PaymentClient;
+import com.example.order.client.PaymentDto;
+import com.example.order.domain.Order;
+import com.example.order.domain.OrderRepository;
+import java.math.BigDecimal;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class OrderService {
+
+    private final OrderRepository orderRepository;
+    private final PaymentClient paymentClient;
+
+    // конструкторная инъекция: зависимости final, легко тестировать, нет скрытого NPE
+    public OrderService(OrderRepository orderRepository, PaymentClient paymentClient) {
+        this.orderRepository = orderRepository;
+        this.paymentClient = paymentClient;
+    }
+
+    @Transactional
+    public Order createOrder(Long customerId, BigDecimal amount) {
+        var order = orderRepository.save(new Order(customerId, amount));
+
+        // синхронный межсервисный вызов; при недоступности сработает fallback → "UNKNOWN"
+        PaymentDto payment = paymentClient.getByOrder(order.getId());
+        if ("PAID".equals(payment.state())) {
+            order.markPaid();
+        }
+        return order;
+    }
+}
+```
+
+> Важно: сетевой вызов внутри `@Transactional` держит открытой транзакцию БД на время ожидания сети. В нагруженном коде это антипаттерн (соединение к БД занято, пока ждём чужой сервис). В проде оплату обычно делают **асинхронно** (событие в Kafka + outbox), а не синхронно под транзакцией. Здесь показано синхронно ради наглядности — держите этот нюанс в голове.
+
+### 5. Контроллер — тонкий, только делегирует
+
+```java
+package com.example.order.web;
+
+import com.example.order.domain.Order;
+import com.example.order.service.OrderService;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+import java.math.BigDecimal;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/orders")
+public class OrderController {
+
+    private final OrderService orderService;
+
+    public OrderController(OrderService orderService) {
+        this.orderService = orderService;
+    }
+
+    @PostMapping
+    public ResponseEntity<OrderResponse> create(@Valid @RequestBody CreateOrderRequest request) {
+        Order order = orderService.createOrder(request.customerId(), request.amount());
+        var body = new OrderResponse(order.getId(), order.getStatus().name());
+        return ResponseEntity.status(HttpStatus.CREATED).body(body);
+    }
+
+    public record CreateOrderRequest(
+            @NotNull Long customerId,
+            @NotNull @Positive BigDecimal amount) {
+    }
+
+    public record OrderResponse(Long id, String status) {
+    }
+}
+```
+
+### 6. Конфигурация приложения (`application.yml`)
+
+```yaml
+spring:
+  application:
+    name: order-service          # это имя увидят discovery и трассировка
+  datasource:
+    url: jdbc:postgresql://localhost:5432/orders
+    username: ${DB_USER}         # секреты — из окружения/секрет-менеджера, НЕ в yml
+    password: ${DB_PASSWORD}
+  jpa:
+    hibernate:
+      ddl-auto: validate          # схему катает Liquibase/Flyway, не Hibernate
+    properties:
+      hibernate:
+        jdbc:
+          time_zone: UTC
+
+management:
+  tracing:
+    sampling:
+      probability: 1.0            # 100% трейсов в dev; в проде обычно 0.1
+  zipkin:
+    tracing:
+      endpoint: http://localhost:9411/api/v2/spans
+
+# circuit breaker по умолчанию: 50% ошибок из окна → open на 5с
+resilience4j:
+  circuitbreaker:
+    instances:
+      payment-service:
+        sliding-window-size: 10
+        failure-rate-threshold: 50
+        wait-duration-in-open-state: 5s
+```
+
+Точка входа с включённым Feign:
+
+```java
+package com.example.order;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cloud.openfeign.EnableFeignClients;
+
+@SpringBootApplication
+@EnableFeignClients // включает сканирование @FeignClient-интерфейсов
+public class OrderServiceApplication {
+
+    public static void main(String[] args) {
+        SpringApplication.run(OrderServiceApplication.class, args);
+    }
+}
+```
+
+### 7. Миграция схемы (SQL, PostgreSQL)
+
+```sql
+CREATE TABLE orders (
+    id          BIGINT GENERATED BY DEFAULT AS IDENTITY PRIMARY KEY,
+    customer_id BIGINT         NOT NULL,
+    amount      NUMERIC(19, 2) NOT NULL CHECK (amount > 0),
+    status      VARCHAR(32)    NOT NULL,
+    created_at  TIMESTAMPTZ    NOT NULL DEFAULT now()
+);
+
+CREATE INDEX orders_customer_id_idx ON orders (customer_id);
+```
+
+---
+
+## Частые ошибки / подводные камни
+
+1. **Полевая инъекция вместо конструкторной.** `@Autowired private PaymentClient client;` прячет зависимости, ломает `final`, мешает тестировать и позволяет создать объект в невалидном состоянии. Всегда — конструктор (см. `OrderService` выше). Для одного конструктора даже `@Autowired` не нужен.
+
+2. **`@Transactional` на private/self-invocation методе.** Spring оборачивает бин прокси; вызов `this.doWork()` внутри того же класса или `private`-метод **проходит мимо прокси** — транзакция не откроется, и вы этого не заметите, пока не словите частичный коммит. Транзакционный метод должен быть `public` и вызываться *через бин* (другой бин или инжектированный self). Плюс: не держите сетевые вызовы внутри транзакции (см. заметку к `OrderService`).
+
+3. **Ретрай неидемпотентной операции.** Соблазн: обернуть *любой* Feign-вызов в `@Retry`. Но если вы ретраите `POST /payments` (списание денег), а первый запрос *дошёл*, но ответ потерялся — вы спишете дважды. Ретраить можно только идемпотентные операции (GET, или POST с ключом идемпотентности). Подробно — раздел **«Надёжность и архитектура»**.
+
+4. **Микросервисы с общей БД.** Разрезали код на сервисы, но все ходят в одну схему PostgreSQL — получили «распределённый монолит»: сервисы связаны через таблицы, нельзя менять схему независимо, транзакционные границы размыты. Правило: **у каждого сервиса — своя БД**, общение — только через API/события, никогда через чужие таблицы.
+
+5. **Секреты в конфиге / в Git.** Пароль БД, ключи API прямо в `application.yml`, закоммиченном в репозиторий, — утечка ждёт своего часа. Секреты — только через переменные окружения, Vault или k8s `Secret`. В `application.yml` — плейсхолдеры `${DB_PASSWORD}`.
+
+6. **Синхронная цепочка вызовов без circuit breaker.** `A → B → C → D` синхронно, и D затормозил. Без предохранителя потоки A/B/C копятся в ожидании, пулы исчерпываются — **каскадное падение** всей цепочки из-за одного медленного сервиса. Каждый исходящий вызов должен иметь таймаут + circuit breaker + осмысленный fallback.
+
+7. **Stateful там, где нужен stateless.** Храните сессию/кэш в памяти инстанса — и при масштабировании до 3 реплик пользователь, попавший на другую реплику, «теряет» состояние. Сервисы за балансировщиком должны быть **stateless**; состояние — во внешнем хранилище (Redis, БД).
+
+---
+
+## Практическая задача
+
+**Контекст.** Вы развиваете `order-service` (код выше). Появился сервис `catalog-service`, который отдаёт актуальную цену и остаток товара. Теперь при создании заказа `order-service` должен сходить в `catalog-service`, проверить, что товар в наличии, и взять цену *оттуда* (не доверять цене от клиента).
+
+**Дано:**
+- `order-service` — как в примерах (PostgreSQL, Feign, Resilience4j, трассировка уже подключены).
+- `catalog-service` предоставляет эндпоинт `GET /items/{sku}` → `{ "sku": "...", "price": 1990.00, "available": 42 }`.
+- `catalog-service` живёт нестабильно: иногда отвечает за 3+ секунды или отдаёт 503.
+
+**ТЗ.** Доработать создание заказа так, чтобы:
+1. Запрос на создание заказа принимал `sku` и `quantity` (а не `amount` — сумму считаем сами).
+2. `order-service` дёргал `catalog-service` через **новый Feign-клиент** `CatalogClient`.
+3. Итоговая сумма считалась как `price × quantity` по цене из каталога.
+4. Если `quantity > available` — заказ **не** создаётся, клиент получает `409 Conflict` с внятным сообщением.
+5. Вызов каталога был защищён: **таймаут** (не ждать дольше 2 с) и **circuit breaker**; при недоступности каталога заказ **не создаётся молча с мусорной ценой**, а возвращается `503 Service Unavailable` — то есть fallback здесь НЕ должен «придумывать» цену.
+6. `traceId` вызова к каталогу был виден в трейсе (проверить, что span появляется в Zipkin).
+
+**Критерии приёмки:**
+- [ ] `POST /api/orders` с `{ "customerId": 1, "sku": "ABC", "quantity": 3 }` создаёт заказ с суммой `price×3` и статусом `NEW`.
+- [ ] При `quantity` больше остатка — `409`, заказ в БД не появился (проверить, что транзакция откатилась / запись не создана).
+- [ ] При остановленном `catalog-service` — ответ `503` за ≤2 с (а не зависание на 30 с дефолтного таймаута), заказ не создан.
+- [ ] После нескольких ошибок подряд circuit breaker в состоянии `open` (видно в `/actuator/health` или метриках), и запросы отсекаются *сразу*, не дожидаясь таймаута.
+- [ ] В Zipkin у запроса создания заказа виден дочерний span вызова `catalog-service`.
+
+**Подсказки (без готового решения):**
+- Отличайте *бизнес-отказ* (нет остатка → `409`, это валидный ответ, **не** повод открывать circuit breaker) от *технического* (таймаут/503 → `503`). Настройте `recordExceptions`/`ignoreExceptions` в Resilience4j так, чтобы `409` не считался «ошибкой сервиса».
+- Для правила «не придумывать цену» fallback должен **бросать** исключение, которое ваш `@ControllerAdvice` замапит в `503` — а не возвращать фейковый `CatalogDto`.
+- Таймаут Feign настраивается через `spring.cloud.openfeign.client.config.catalog-service.read-timeout` (либо через `TimeLimiter` Resilience4j).
+- Валидацию остатка и подсчёт суммы делайте **в сервисе**, не в контроллере (контроллер тонкий).
+- Не забудьте, что при `409` не должно остаться записи в БД — где у вас граница транзакции и когда происходит проверка остатка относительно `save()`?
+
+---
+
+## Что почитать
+
+- **Spring Cloud OpenFeign — референс:** https://docs.spring.io/spring-cloud-openfeign/reference/
+- **Spring Cloud Gateway — референс:** https://docs.spring.io/spring-cloud-gateway/reference/
+- **Distributed Tracing в Spring Boot 3 (Micrometer Tracing), официальная дока:** https://docs.spring.io/spring-boot/reference/actuator/tracing.html
+- **Resilience4j — официальная документация (Circuit Breaker, Retry, TimeLimiter):** https://resilience4j.readme.io/docs/getting-started
+- **Guide: Spring Cloud Circuit Breaker (spring.io/guides):** https://spring.io/guides/gs/cloud-circuit-breaker
+- **Baeldung — Introduction to Spring Cloud OpenFeign:** https://www.baeldung.com/spring-cloud-openfeign

--- a/src/main/resources/other/spring/spring-core.md
+++ b/src/main/resources/other/spring/spring-core.md
@@ -1,0 +1,559 @@
+# Spring (Core, IoC/DI)
+
+## Зачем это нужно / какую проблему решает
+
+Представь сервис оформления заказов. `OrderService` считает цену, сохраняет заказ в БД и шлёт письмо клиенту. Пишешь честно, руками:
+
+```java
+public class OrderService {
+    private final OrderRepository repository;
+    private final PricingService pricing;
+    private final EmailNotifier notifier;
+
+    public OrderService() {
+        // сами создаём весь граф зависимостей
+        DataSource ds = new HikariDataSource(buildConfig());
+        this.repository = new JdbcOrderRepository(ds);
+        this.pricing = new PricingService(new TaxRateClient("https://tax.api"));
+        this.notifier = new EmailNotifier(new SmtpClient("smtp.internal", 587));
+    }
+}
+```
+
+Что здесь плохо — и с каждым месяцем всё хуже:
+
+- **Жёсткая связанность.** `OrderService` намертво знает про `JdbcOrderRepository`, `Hikari`, SMTP-хост и порт. Захотел заменить БД на кафку, SMTP на мок — правишь конструктор бизнес-класса.
+- **Граф объектов собирается вручную.** `DataSource` нужен и репозиторию заказов, и репозиторию клиентов, и репозиторию платежей. Каждый создаёт свой пул соединений — вместо одного общего у тебя их десять. Кто-то забыл закрыть — утечка.
+- **Тестировать невозможно.** Чтобы протестировать расчёт цены, поднимается реальный SMTP и реальная БД, потому что они зашиты в конструктор. Подменить нечем.
+- **Конфигурация размазана.** Хост, порт, URL прибиты гвоздями в коде вместо внешнего файла. Секреты — там же (привет, git-история).
+
+Корень боли: **класс сам отвечает и за свою бизнес-логику, и за создание своих зависимостей.** Это две разные ответственности, и вторая расползается по всему коду.
+
+**Inversion of Control (IoC)** переворачивает это: не объект создаёт свои зависимости, а внешний контейнер создаёт объекты и *отдаёт* им готовые зависимости. **Dependency Injection (DI)** — конкретный механизм: зависимости «вкалываются» снаружи через конструктор.
+
+С Spring тот же сервис выглядит так:
+
+```java
+@Service
+public class OrderService {
+    private final OrderRepository repository;
+    private final PricingService pricing;
+    private final EmailNotifier notifier;
+
+    // Spring сам найдёт и передаст готовые бины
+    public OrderService(OrderRepository repository, PricingService pricing, EmailNotifier notifier) {
+        this.repository = repository;
+        this.pricing = pricing;
+        this.notifier = notifier;
+    }
+}
+```
+
+Класс больше не знает, *откуда* берутся зависимости и *как* они устроены. Он объявляет: «мне нужны эти три штуки». Сборкой графа, единственным пулом соединений, порядком инициализации и подстановкой моков в тестах занимается контейнер. Связанность падает, тестируемость взлетает, конфигурация уезжает во внешние файлы и профили.
+
+Это не магия — это фабрика объектов на стероидах, про которую мы дальше разберём, что именно она делает.
+
+## Ключевые понятия
+
+### IoC-контейнер и бины
+
+**Бин (bean)** — это объект, жизненным циклом которого управляет Spring: он его создаёт, конфигурирует, связывает с другими бинами и уничтожает. Твой `OrderService`, `OrderRepository`, `DataSource` — всё это бины.
+
+**IoC-контейнер** — фабрика, которая держит реестр всех бинов, знает их зависимости и умеет собрать корректный граф. По умолчанию каждый бин — **синглтон**: один экземпляр на весь контейнер, переиспользуется везде, где он нужен. Именно поэтому пул соединений становится один на всё приложение, а не десять.
+
+Контейнер работает в две фазы:
+1. **Регистрация определений бинов** (bean definitions) — сканирование классов и конфигураций, построение «чертежей»: какой класс, какой scope, какие зависимости.
+2. **Создание и связывание** — контейнер инстанцирует бины в правильном порядке (сначала зависимости, потом зависящих) и внедряет их друг в друга.
+
+### ApplicationContext
+
+`ApplicationContext` — это и есть тот самый контейнер в его боевой ипостаси. Помимо реестра бинов он даёт: публикацию событий, интернационализацию, доступ к ресурсам и, главное, интеграцию с автоконфигурацией Spring Boot.
+
+В Spring Boot ты почти никогда не создаёшь контекст руками — это делает `@SpringBootApplication`:
+
+```java
+@SpringBootApplication
+public class OrderApplication {
+    public static void main(String[] args) {
+        SpringApplication.run(OrderApplication.class, args);
+        // внутри: создан ApplicationContext, просканированы бины,
+        // собран граф, поднят встроенный Tomcat
+    }
+}
+```
+
+`@SpringBootApplication` — это composed-аннотация: `@Configuration` + `@ComponentScan` (сканирует пакет класса и вложенные) + `@EnableAutoConfiguration`.
+
+### Как объявляются бины
+
+Два основных способа.
+
+**1. Стереотипные аннотации + компонент-сканирование.** Вешаешь аннотацию на класс, а `@ComponentScan` его подхватывает:
+
+- `@Component` — базовый стереотип, «это бин».
+- `@Service` — бин с бизнес-логикой (семантически = `@Component`, но читается яснее).
+- `@Repository` — бин доступа к данным; вдобавок Spring транслирует специфичные для БД исключения в общий `DataAccessException`.
+- `@Controller` / `@RestController` — веб-слой.
+
+Технически для контейнера все они — `@Component`. Разница в намерении (и в паре побочных бонусов у `@Repository`/`@Controller`).
+
+**2. `@Configuration` + `@Bean`.** Нужно, когда объект не твой (класс из библиотеки, аннотацию не повесить) или создание нетривиально:
+
+```java
+@Configuration
+public class HttpClientConfig {
+
+    @Bean
+    public RestClient taxApiClient(@Value("${tax.api.base-url}") String baseUrl) {
+        return RestClient.builder().baseUrl(baseUrl).build();
+    }
+}
+```
+
+Метод, помеченный `@Bean`, возвращает объект — его возвращаемое значение и становится бином. Имя бина по умолчанию = имя метода.
+
+### Инъекция зависимостей: конструкторная — по умолчанию
+
+Три вида инъекции, но использовать надо один.
+
+**Конструкторная (предпочтительная).** Зависимости приходят параметрами конструктора:
+
+```java
+@Service
+public class OrderService {
+    private final OrderRepository repository; // final — гарантия неизменности
+
+    public OrderService(OrderRepository repository) {
+        this.repository = repository;
+    }
+}
+```
+
+Почему она правильная:
+- Поля можно сделать `final` → **иммутабельность**, объект нельзя оставить полусобранным.
+- Зависимости **обязательны и видны** в сигнатуре: класс с 8 параметрами конструктора честно кричит, что он God-object и его пора дробить.
+- Объект **тестируется без Spring** — в тесте просто `new OrderService(mockRepo)`.
+- Если начиная со Spring 4.3 у класса **один конструктор**, `@Autowired` над ним не нужен — контейнер и так поймёт. С Lombok — `@RequiredArgsConstructor` генерирует конструктор по `final`-полям.
+
+**Полевая (`@Autowired` на поле) — не использовать.** Поле нельзя сделать `final`, зависимости скрыты, без Spring класс не инстанцируется, легко получить `null`:
+
+```java
+@Service
+public class BadService {
+    @Autowired private OrderRepository repository; // так не надо
+}
+```
+
+**Сеттерная** — узкая ниша: действительно опциональные зависимости или разрыв редких циклических связей. В обычном коде — почти никогда.
+
+Если под тип подходит несколько бинов, разрулить неоднозначность помогают `@Qualifier("beanName")` и `@Primary` (пометить один как «по умолчанию»).
+
+### Scope бинов
+
+**Scope** определяет, сколько экземпляров бина живёт и как долго:
+
+- `singleton` (по умолчанию) — один на контейнер. **Обязан быть stateless**: его дёргают конкурентно из многих потоков.
+- `prototype` — новый экземпляр на каждый запрос из контейнера.
+- `request` / `session` (web) — на HTTP-запрос / HTTP-сессию.
+
+99% бинов — синглтоны. Это накладывает правило: **не храни в синглтоне изменяемое состояние запроса** (текущего юзера, счётчик, «последний заказ»). Общий мутабельный state в синглтоне под нагрузкой = гонки данных и плавающие баги.
+
+### Жизненный цикл бина
+
+Что происходит с бином от рождения до смерти:
+
+1. Контейнер читает bean definition.
+2. Инстанцирование (вызов конструктора → сюда приходит конструкторная инъекция).
+3. Заполнение остальных зависимостей (сеттеры/поля, если есть).
+4. Коллбэки инициализации: метод с `@PostConstruct` → тут прогревают кеши, проверяют конфиг. На этом этапе все зависимости уже на месте.
+5. Бин готов и живёт в контексте.
+6. При остановке приложения — `@PreDestroy`: закрыть пулы, слить буферы.
+
+```java
+@Component
+public class WarmupCache {
+    @PostConstruct
+    void init() { /* зависимости уже внедрены, можно прогревать */ }
+
+    @PreDestroy
+    void shutdown() { /* освободить ресурсы */ }
+}
+```
+
+Важно: **конструктор ≠ место для тяжёлой инициализации**. В конструкторе делай только присваивание зависимостей; всё, что требует уже собранного объекта, — в `@PostConstruct`.
+
+### Профили и внешняя конфигурация
+
+**Профиль** — именованный набор бинов/настроек под окружение (`dev`, `test`, `prod`).
+
+```java
+@Configuration
+@Profile("prod")
+public class ProdNotifierConfig {
+    @Bean
+    EmailNotifier emailNotifier() { return new SmtpEmailNotifier(); }
+}
+
+@Configuration
+@Profile("!prod") // всё, кроме prod
+public class LocalNotifierConfig {
+    @Bean
+    EmailNotifier emailNotifier() { return new LoggingEmailNotifier(); }
+}
+```
+
+Активный профиль: `SPRING_PROFILES_ACTIVE=prod` или `--spring.profiles.active=prod`. Настройки для профиля — в `application-prod.yml` поверх базового `application.yml`.
+
+Значения тянутся снаружи через `@Value("${...}")` или типобезопасно через `@ConfigurationProperties`. **Секреты в файлах и git не хранятся** — они приходят из переменных окружения / секрет-хранилища.
+
+### Чем это отличается от «магии»
+
+Со стороны кажется, что бины возникают из воздуха. Внутри — детерминированный процесс без рефлексии-волшебства «на удачу»:
+
+- **Компонент-сканирование** — Spring обходит classpath в указанных пакетах и ищет классы со стереотипными аннотациями. Это обычный обход, а не ясновидение.
+- **Разрешение зависимостей** — по типу (и по имени при неоднозначности) контейнер сопоставляет, какой бин куда подставить. Не нашёл кандидата или нашёл двух — падает при старте с внятной ошибкой, а не молча в рантайме.
+- **Прокси для `@Transactional`/`@Cacheable`/`@Async`** — Spring оборачивает бин прокси-объектом, который перехватывает вызовы публичных методов *извне* и добавляет поведение (открыть транзакцию, закешировать). Отсюда два важных следствия: аннотации работают только на публичных методах и только при вызове через бин (не через `this`).
+
+Понимаешь эти три механизма — и «магия» превращается в предсказуемый инструмент, а ошибки старта читаются с первого раза.
+
+## Примеры на Java
+
+Сквозной пример: заказы. Сущность → репозиторий → сервис → контроллер → конфиг. Всё на Java 21 / Spring Boot 3, импорты `jakarta.*`.
+
+**Сущность (JPA, Jakarta).**
+
+```java
+package com.example.order.model;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.math.BigDecimal;
+import java.time.Instant;
+
+@Entity
+@Table(name = "orders")
+public class Order {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private Long customerId;
+
+    @Column(nullable = false)
+    private BigDecimal amount;
+
+    @Enumerated(EnumType.STRING) // храним строкой, а не хрупким ordinal
+    @Column(nullable = false)
+    private OrderStatus status;
+
+    @Column(nullable = false)
+    private Instant createdAt;
+
+    protected Order() { } // требование JPA
+
+    public Order(Long customerId, BigDecimal amount) {
+        this.customerId = customerId;
+        this.amount = amount;
+        this.status = OrderStatus.NEW;
+        this.createdAt = Instant.now();
+    }
+
+    // меняем состояние осмысленным методом, а не публичным сеттером
+    public void markPaid() {
+        if (status != OrderStatus.NEW) {
+            throw new IllegalStateException("Оплатить можно только новый заказ, текущий статус: " + status);
+        }
+        this.status = OrderStatus.PAID;
+    }
+
+    public Long getId() { return id; }
+    public Long getCustomerId() { return customerId; }
+    public BigDecimal getAmount() { return amount; }
+    public OrderStatus getStatus() { return status; }
+    public Instant getCreatedAt() { return createdAt; }
+}
+```
+
+```java
+package com.example.order.model;
+
+public enum OrderStatus { NEW, PAID, CANCELLED }
+```
+
+**Репозиторий (Spring Data JPA).** Интерфейс — реализацию Spring генерирует сам, это тоже бин.
+
+```java
+package com.example.order.repository;
+
+import com.example.order.model.Order;
+import com.example.order.model.OrderStatus;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface OrderRepository extends JpaRepository<Order, Long> {
+    List<Order> findByCustomerIdAndStatus(Long customerId, OrderStatus status);
+}
+```
+
+**Сервис — конструкторная инъекция.**
+
+```java
+package com.example.order.service;
+
+import com.example.order.model.Order;
+import com.example.order.repository.OrderRepository;
+import java.math.BigDecimal;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class OrderService {
+
+    private final OrderRepository repository;
+    private final EmailNotifier notifier;
+
+    // единственный конструктор — @Autowired не нужен
+    public OrderService(OrderRepository repository, EmailNotifier notifier) {
+        this.repository = repository;
+        this.notifier = notifier;
+    }
+
+    @Transactional // публичный метод, вызывается через прокси-бин — транзакция откроется
+    public Order placeOrder(Long customerId, BigDecimal amount) {
+        Order order = repository.save(new Order(customerId, amount));
+        notifier.notifyCreated(order.getId());
+        return order;
+    }
+
+    @Transactional(readOnly = true)
+    public Order getById(Long id) {
+        return repository.findById(id)
+            .orElseThrow(() -> new OrderNotFoundException(id));
+    }
+}
+```
+
+**Абстракция уведомителя + две реализации под профили.**
+
+```java
+package com.example.order.service;
+
+public interface EmailNotifier {
+    void notifyCreated(Long orderId);
+}
+```
+
+```java
+package com.example.order.service;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Component;
+
+@Component
+@Profile("!prod") // локально и в тестах просто логируем
+public class LoggingEmailNotifier implements EmailNotifier {
+    private static final Logger log = LoggerFactory.getLogger(LoggingEmailNotifier.class);
+
+    @Override
+    public void notifyCreated(Long orderId) {
+        log.info("[stub-email] Заказ {} создан", orderId);
+    }
+}
+```
+
+**Контроллер — тонкий, только делегирует.**
+
+```java
+package com.example.order.controller;
+
+import com.example.order.model.Order;
+import com.example.order.service.OrderService;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+import java.math.BigDecimal;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/orders")
+public class OrderController {
+
+    private final OrderService orderService;
+
+    public OrderController(OrderService orderService) {
+        this.orderService = orderService;
+    }
+
+    // DTO запроса как record — иммутабельный, с bean-validation
+    public record CreateOrderRequest(
+        @NotNull Long customerId,
+        @NotNull @Positive BigDecimal amount) { }
+
+    @PostMapping
+    public ResponseEntity<Order> create(@Valid @RequestBody CreateOrderRequest req) {
+        Order order = orderService.placeOrder(req.customerId(), req.amount());
+        return ResponseEntity.status(HttpStatus.CREATED).body(order);
+    }
+
+    @GetMapping("/{id}")
+    public Order get(@PathVariable Long id) {
+        return orderService.getById(id);
+    }
+}
+```
+
+**`@Configuration` + `@Bean`** для чужого класса (клиент внешнего API).
+
+```java
+package com.example.order.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestClient;
+
+@Configuration
+public class ExternalClientConfig {
+
+    @Bean
+    public RestClient taxApiClient(@Value("${tax.api.base-url}") String baseUrl) {
+        return RestClient.builder().baseUrl(baseUrl).build();
+    }
+}
+```
+
+**Внешняя конфигурация — `application.yml` + профиль.**
+
+```yaml
+# application.yml — базовые настройки
+spring:
+  application:
+    name: order-service
+  datasource:
+    url: jdbc:postgresql://localhost:5432/orders
+    username: ${DB_USER}        # секреты из окружения, не в файле
+    password: ${DB_PASSWORD}
+  jpa:
+    hibernate:
+      ddl-auto: validate        # схему ведёт Liquibase/Flyway, не Hibernate
+    open-in-view: false         # выключаем OSIV — про это в подводных камнях
+
+tax:
+  api:
+    base-url: http://localhost:8081
+```
+
+```yaml
+# application-prod.yml — накатывается поверх при профиле prod
+spring:
+  jpa:
+    properties:
+      hibernate.jdbc.batch_size: 50
+tax:
+  api:
+    base-url: https://tax.internal.company.com
+```
+
+**Схема таблицы (миграция).**
+
+```sql
+CREATE TABLE orders (
+    id          BIGSERIAL PRIMARY KEY,
+    customer_id BIGINT       NOT NULL,
+    amount      NUMERIC(19,2) NOT NULL,
+    status      VARCHAR(32)  NOT NULL,
+    created_at  TIMESTAMPTZ  NOT NULL
+);
+CREATE INDEX orders_customer_id_status_idx ON orders (customer_id, status);
+```
+
+## Частые ошибки / подводные камни
+
+**1. Полевая инъекция вместо конструкторной.** `@Autowired` на приватном поле не даёт сделать его `final`, прячет зависимости, ломает тестирование без Spring и позволяет создать полусобранный объект. Всегда — конструктор (с Lombok `@RequiredArgsConstructor`). Полевую инъекцию оставь только автогенерённому коду.
+
+**2. `@Transactional` (или `@Cacheable`, `@Async`) на private-методе или при self-invocation.** Аннотация работает через прокси, который перехватывает только публичные вызовы *извне*. Вызов `this.doInTx()` внутри того же бина идёт мимо прокси — транзакция не откроется, и ты об этом узнаешь по неконсистентным данным в проде, а не по ошибке.
+
+```java
+public void process(Order o) {
+    save(o); // мимо прокси — транзакции НЕТ
+}
+@Transactional
+public void save(Order o) { ... } // публичный, но вызван через this
+```
+Лечится выносом транзакционного метода в отдельный бин или программной транзакцией через `TransactionTemplate`.
+
+**3. Изменяемое состояние в singleton-бине.** Синглтон обслуживает все потоки одновременно. Поле `private Order lastOrder;` или `private int counter;` в `@Service` — это гонка данных: один запрос затирает данные другого. Сервисы держи **stateless**; всё, что относится к конкретному запросу, передавай параметрами или храни в request-scope.
+
+**4. `FetchType.EAGER` по умолчанию везде и N+1.** `@ManyToOne` по умолчанию EAGER — каждый заказ тянет клиента отдельным запросом, список из 100 заказов = 101 запрос к БД. Ставь `FetchType.LAZY` и подгружай нужное через `JOIN FETCH` / entity graph. Плюс отключай Open-Session-In-View (`spring.jpa.open-in-view=false`), чтобы ленивые загрузки не улетали за пределы сервисного слоя незаметно.
+
+**5. Секреты и окруженческие значения в `application.yml` под git.** Пароль БД, токен платёжки в yml-файле = утечка в первый же `git log`. Секреты — только через переменные окружения (`${DB_PASSWORD}`) или секрет-хранилище; в репозитории лежат лишь плейсхолдеры и несекретные дефолты.
+
+**6. `NoUniqueBeanDefinitionException` — два кандидата на один тип.** Две реализации `EmailNotifier` без разграничения → контейнер не знает, какую внедрять, и падает на старте. Разграничивай профилем (`@Profile`), пометкой основного (`@Primary`) или явным выбором на месте инъекции (`@Qualifier("smtpNotifier")`). Ошибка на старте — это хорошо: лучше, чем неправильный бин в рантайме.
+
+**7. Тяжёлая работа в конструкторе бина.** Обращение к БД, прогрев кеша, HTTP-вызовы в конструкторе выполняются до того, как объект полностью собран и контекст готов, и роняют старт непонятной ошибкой. Всё это — в `@PostConstruct`, где зависимости уже внедрены.
+
+## Практическая задача
+
+**Контекст.** Ты пришёл в сервис, где уведомления клиентам жёстко зашиты в `OrderService`, а `SmtpEmailSender` создаётся прямо в конструкторе через `new`. Тесты не пишутся (поднимается реальный SMTP), локально спам летит на боевой сервер, а перевести часть уведомлений с email на «пуш» без переписывания сервиса нельзя.
+
+**Дано (упрощённо, реальный «плохой» код):**
+
+```java
+@Service
+public class OrderService {
+    @Autowired
+    private OrderRepository repository; // полевая инъекция
+
+    private final SmtpEmailSender sender = new SmtpEmailSender("smtp.prod:587"); // хост в коде
+
+    public Order placeOrder(Long customerId, BigDecimal amount) {
+        Order order = repository.save(new Order(customerId, amount));
+        sender.send(customerId, "Заказ " + order.getId() + " создан");
+        return order;
+    }
+}
+```
+
+**ТЗ.** Переработай так, чтобы способ доставки уведомления был подменяемым и настраивался окружением, а сервис стал тестируемым без внешних систем:
+
+1. Введи абстракцию `OrderNotifier` (интерфейс) и две реализации: боевую (`EmailOrderNotifier`) и локальную/тестовую заглушку (`LoggingOrderNotifier`), которая только пишет в лог.
+2. Перепиши `OrderService` на **конструкторную инъекцию**; все поля — `final`, никакого `new` для зависимостей внутри класса.
+3. Настрой выбор реализации **профилем**: `prod` → email, всё остальное → заглушка. На старте приложения должна подниматься ровно одна реализация `OrderNotifier` (никаких `NoUniqueBeanDefinitionException`).
+4. SMTP-хост и порт вынеси во внешнюю конфигурацию (`application-prod.yml` / переменные окружения), убери из кода.
+5. Сделай так, чтобы отправка уведомления происходила **в той же транзакции**, что и сохранение заказа, но с учётом того, что `@Transactional` работает через прокси (не сломай self-invocation).
+
+**Критерии приёмки.**
+- В `OrderService` нет ни `@Autowired` на поле, ни `new` для зависимостей; конструктор один, поля `final`.
+- Запуск с `--spring.profiles.active=prod` поднимает `EmailOrderNotifier`, без профиля/с `test` — `LoggingOrderNotifier`; в обоих случаях контекст стартует.
+- SMTP-хост нигде не захардкожен; при отсутствии переменной окружения это видно из конфига, а не спрятано в коде.
+- Можно написать функциональный тест `placeOrder`, не поднимая реальный SMTP.
+
+**Подсказки (без готового решения).**
+- Разграничить два бина одного типа помогает `@Profile("prod")` / `@Profile("!prod")`, либо `@Primary` + `@Qualifier`.
+- Значения из yml прокидываются в `@Bean`-метод или конструктор через `@Value("${...}")`, либо типобезопасно через `@ConfigurationProperties`.
+- Если захочешь сделать уведомление устойчивым к сбоям SMTP (ретраи, чтобы одно и то же письмо не ушло дважды) — это уже про идемпотентность и повторные попытки: смотри раздел роадмапа **«Надёжность и архитектура»**, здесь достаточно чистой развязки зависимостей.
+- Проверь себя: попробуй в тесте `new OrderService(mockRepo, mockNotifier)` — если компилируется и работает без Spring, развязка удалась.
+
+## Что почитать
+
+- [Spring Framework Reference — Core Technologies (IoC Container, Beans)](https://docs.spring.io/spring-framework/reference/core/beans.html) — первоисточник по контейнеру, определениям бинов, scope и жизненному циклу.
+- [Spring Boot Reference — Spring Boot Features (Externalized Configuration, Profiles)](https://docs.spring.io/spring-boot/reference/features/external-config.html) — как устроены `application.yml`, профили и приоритет источников настроек в Boot 3.
+- [Guide: Constructor Dependency Injection in Spring (Baeldung)](https://www.baeldung.com/constructor-injection-in-spring) — предметный разбор, почему конструкторная инъекция предпочтительнее полевой и сеттерной.
+- [Spring Data JPA Reference](https://docs.spring.io/spring-data/jpa/reference/jpa.html) — репозитории как бины, деривация запросов, транзакции и связь с Hibernate 6.

--- a/src/main/resources/other/spring/spring-data.md
+++ b/src/main/resources/other/spring/spring-data.md
@@ -1,0 +1,553 @@
+# Spring Data JPA
+
+## Зачем это нужно / какую проблему решает
+
+Представь: у тебя есть таблица `orders` и сущность `Order`. Тебе нужно «найти заказ по id», «найти все заказы продавца со статусом `PACKING`, отсортированные по дате», «постранично отдать заказы за последний месяц». В голом JDBC/JPA под каждую такую операцию ты пишешь один и тот же ритуал:
+
+```java
+// Классический DAO на «голом» EntityManager — так делать НЕ надо
+public class OrderDaoImpl {
+    @PersistenceContext
+    private EntityManager em;
+
+    public Optional<Order> findById(Long id) {
+        return Optional.ofNullable(em.find(Order.class, id));
+    }
+
+    public List<Order> findBySellerAndStatus(Long sellerId, OrderStatus status) {
+        return em.createQuery(
+                "select o from Order o where o.sellerId = :s and o.status = :st", Order.class)
+            .setParameter("s", sellerId)
+            .setParameter("st", status)
+            .getResultList();
+    }
+    // ... и так на каждый чих: save, delete, count, exists, paging...
+}
+```
+
+Это **boilerplate** — механический код, который ничего не рассказывает о бизнесе, но который надо написать, покрыть тестами и поддерживать. На реальном сервисе таких DAO десятки, и 80% их методов — это тривиальные «найди по полю / сохрани / посчитай».
+
+**Spring Data JPA** убирает этот слой почти целиком. Ты объявляешь **интерфейс**, а реализацию Spring генерирует в рантайме — по имени метода, по аннотации `@Query` или из набора стандартных CRUD-операций. Вместо сотен строк DAO — декларация контракта:
+
+```java
+public interface OrderRepository extends JpaRepository<Order, Long> {
+    List<Order> findBySellerIdAndStatus(Long sellerId, OrderStatus status);
+}
+```
+
+Всё. `save`, `findById`, `findAll`, `count`, `delete`, пагинация, сортировка — уже есть в `JpaRepository`. Метод `findBySellerIdAndStatus` Spring разберёт по имени и сгенерирует JPQL. Ты пишешь только то, что нетривиально, и тратишь время на бизнес-логику, а не на перекладывание строк из `ResultSet`.
+
+Важно понимать границу: Spring Data JPA — это **тонкая обёртка над JPA/Hibernate**, а не отдельная ORM. Под капотом всё тот же `EntityManager`, тот же persistence context, те же правила транзакций и ленивой загрузки. Поэтому все классические грабли JPA (N+1, `LazyInitializationException`, каскады) никуда не деваются — просто теперь они спрятаны за красивым интерфейсом, и важно понимать, что происходит внутри.
+
+## Ключевые понятия
+
+### Иерархия репозиториев
+
+Spring Data строит репозитории на иерархии интерфейсов-маркеров:
+
+- `Repository<T, ID>` — пустой корневой маркер.
+- `CrudRepository<T, ID>` — `save`, `findById`, `findAll`, `delete`, `count`, `existsById`.
+- `PagingAndSortingRepository<T, ID>` — добавляет `findAll(Pageable)` и `findAll(Sort)`.
+- `JpaRepository<T, ID>` — JPA-специфика: `saveAll`, `flush`, `saveAndFlush`, `getReferenceById`, `findAll` возвращает `List` (а не `Iterable`).
+
+В 99% случаев наследуешь `JpaRepository<Entity, IdType>` и получаешь весь CRUD + пагинацию бесплатно. Реализацию (`SimpleJpaRepository`) Spring подставляет сам через прокси — своего класса писать не нужно.
+
+### Derived query methods (запросы по имени метода)
+
+Spring парсит **имя метода** и генерирует запрос. Грамматика: `find|read|get|query|count|exists|delete` + `By` + условия через `And`/`Or` + ключевые слова.
+
+```java
+List<Order> findBySellerId(Long sellerId);
+List<Order> findBySellerIdAndStatus(Long sellerId, OrderStatus status);
+List<Order> findByStatusInAndCreatedAtAfter(Collection<OrderStatus> statuses, Instant after);
+Optional<Order> findFirstBySellerIdOrderByCreatedAtDesc(Long sellerId);
+long countByStatus(OrderStatus status);
+boolean existsByPublicId(String publicId);
+```
+
+Ключевые слова: `Between`, `LessThan`, `GreaterThanEqual`, `Like`, `Containing`, `StartingWith`, `In`, `IsNull`, `True/False`, `IgnoreCase`, `OrderBy...Asc/Desc`, `Distinct`, `First`/`Top`.
+
+Правило: derived-методы хороши, пока имя читается как фраза. Как только имя превращается в `findBySellerIdAndStatusInAndCreatedAtBetweenAndDeletedFalseOrderByCreatedAtDesc` — это сигнал перейти на `@Query`.
+
+### @Query — JPQL и native
+
+Когда имя метода уже не тянет (сложные условия, join'ы, агрегаты, `update`), пишешь запрос явно.
+
+**JPQL** (работает с сущностями и их полями, а не с таблицами/колонками):
+
+```java
+@Query("select o from Order o where o.sellerId = :sellerId and o.status = :status")
+List<Order> findActive(@Param("sellerId") Long sellerId, @Param("status") OrderStatus status);
+```
+
+**Native** (сырой SQL, когда нужны специфичные фичи БД — оконные функции, `ON CONFLICT`, CTE):
+
+```java
+@Query(value = "select * from orders o where o.seller_id = :sellerId "
+             + "and o.created_at > now() - interval '30 days'", nativeQuery = true)
+List<Order> findRecentBySeller(@Param("sellerId") Long sellerId);
+```
+
+Модифицирующие запросы требуют `@Modifying` и активной транзакции:
+
+```java
+@Modifying
+@Query("update Order o set o.status = :status where o.id = :id")
+int updateStatus(@Param("id") Long id, @Param("status") OrderStatus status);
+```
+
+`@Modifying(clearAutomatically = true, flushAutomatically = true)` — если после массового `update` в той же транзакции продолжаешь работать с этими сущностями, иначе persistence context будет содержать устаревшие данные (bulk-запрос идёт мимо контекста первого уровня).
+
+### Пагинация и сортировка (Pageable / Sort)
+
+Не тащи всю таблицу в память — отдавай страницами.
+
+```java
+Page<Order> findBySellerId(Long sellerId, Pageable pageable);
+Slice<Order> findByStatus(OrderStatus status, Pageable pageable);
+```
+
+- `Page<T>` — содержит контент + **общее число элементов** (делает дополнительный `count`-запрос). Нужен, когда рисуешь «страница 3 из 47».
+- `Slice<T>` — знает только «есть ли следующая страница» (`hasNext()`), без `count`. Дешевле — для бесконечной прокрутки.
+- `Pageable` собирается через `PageRequest.of(page, size, Sort.by(...))`.
+
+`Sort` — типобезопасная сортировка, передаётся отдельно или внутри `Pageable`:
+
+```java
+var pageable = PageRequest.of(0, 20, Sort.by(Sort.Direction.DESC, "createdAt"));
+```
+
+### @Transactional
+
+Транзакция — это граница, внутри которой живёт **persistence context** (кэш первого уровня) и в конце которой изменённые managed-сущности синхронизируются с БД (dirty checking + flush).
+
+- Методы `JpaRepository` уже транзакционные: чтения — `readonly`, записи — обычные.
+- Свою транзакцию открываешь на **сервисном** методе, когда несколько операций должны быть атомарны или когда нужен «грязный» апдейт через dirty checking без явного `save`.
+
+```java
+@Transactional
+public void confirm(Long orderId) {
+    Order order = orderRepository.findById(orderId).orElseThrow();
+    order.confirm();                 // меняем состояние managed-сущности
+    // save() не нужен: flush на коммите сам запишет изменения (dirty checking)
+}
+```
+
+Два критичных факта, которые ломают половину проектов новичков:
+1. Spring оборачивает бин **прокси**. Вызов `@Transactional`-метода **из того же класса через `this.method()`** транзакцию НЕ откроет (self-invocation минует прокси).
+2. `@Transactional` на `private`/`protected`/package-private методе не работает — прокси перехватывает только `public` (для CGLIB — ещё и не `final`).
+
+`@Transactional(readOnly = true)` на чтениях — не только «намерение», но и оптимизация: Hibernate переводит сессию в `FlushMode.MANUAL` (не делает лишних flush и dirty-check), и БД может маршрутизировать на реплику.
+
+### Проблема N+1 и способы борьбы
+
+**N+1** — самая частая проблема производительности в JPA. Ты грузишь список из N заказов (1 запрос), а потом в цикле обращаешься к ленивой связи `order.getItems()` — и Hibernate делает **ещё N запросов**, по одному на заказ.
+
+```java
+List<Order> orders = orderRepository.findBySellerId(sellerId); // 1 запрос
+for (Order o : orders) {
+    o.getItems().size();  // +N запросов — по одному на каждый заказ
+}
+```
+
+Способы лечения:
+
+**1. `@EntityGraph`** — декларативно говорим, какие связи подтянуть одним запросом (fetch join под капотом):
+
+```java
+@EntityGraph(attributePaths = {"items"})
+List<Order> findBySellerId(Long sellerId);
+```
+
+**2. Fetch join в JPQL** — то же самое явно:
+
+```java
+@Query("select distinct o from Order o join fetch o.items where o.sellerId = :sellerId")
+List<Order> findBySellerIdWithItems(@Param("sellerId") Long sellerId);
+```
+
+**3. `@BatchSize`** — Hibernate грузит ленивые связи пачками (`IN (...)`), превращая N+1 в N/размер_пачки запросов. Ставится на коллекцию или сущность.
+
+Важно: **fetch join нескольких коллекций одновременно** порождает декартово произведение — join'ить `items` и `payments` в одном запросе нельзя (получишь дубли и предупреждение Hibernate). Тогда либо два `@EntityGraph`-запроса, либо `@BatchSize`.
+
+### DTO-проекции
+
+Не отдавай JPA-сущности наружу (в контроллер/API): тянешь лишние колонки, рискуешь `LazyInitializationException` вне транзакции, протекает доменная модель в контракт. Проецируй в DTO прямо на уровне запроса.
+
+**Интерфейсные проекции** (Spring сам сгенерирует прокси, тянет только нужные колонки):
+
+```java
+public interface OrderSummary {
+    Long getId();
+    OrderStatus getStatus();
+    Instant getCreatedAt();
+}
+
+List<OrderSummary> findBySellerId(Long sellerId);
+```
+
+**Классовые (DTO) проекции через конструктор в JPQL** — `record` идеально подходит:
+
+```java
+public record OrderView(Long id, OrderStatus status, Instant createdAt) {}
+
+@Query("select new com.example.OrderView(o.id, o.status, o.createdAt) from Order o where o.sellerId = :s")
+List<OrderView> findViews(@Param("s") Long sellerId);
+```
+
+Проекция дешевле полной сущности: меньше колонок в `SELECT`, не грузятся ленивые связи, объект detached-безопасен.
+
+### Связь с Hibernate
+
+Spring Data JPA — это **абстракция над JPA API** (`EntityManager`, аннотации `jakarta.persistence.*`). Реализация JPA по умолчанию в Spring Boot — **Hibernate**. Иерархия ответственности:
+
+- **JPA** — спецификация (интерфейсы, аннотации): `@Entity`, `EntityManager`, JPQL.
+- **Hibernate** — конкретная реализация: dirty checking, кэш первого уровня, ленивые прокси, диалекты SQL, `@BatchSize`, `hibernate.jdbc.batch_size`.
+- **Spring Data JPA** — генерация репозиториев, derived-запросы, `Pageable`, декларативные транзакции поверх всего этого.
+
+Поэтому «магия» Spring Data — это на самом деле поведение Hibernate: persistence context, flush на коммите, ленивая инициализация. Понимаешь Hibernate — понимаешь, почему Spring Data ведёт себя именно так.
+
+## Примеры на Java
+
+### Сущность (Jakarta EE, не javax!)
+
+```java
+package com.example.order.model;
+
+import jakarta.persistence.CollectionTable;
+import jakarta.persistence.Column;
+import jakarta.persistence.ElementCollection;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Table(name = "orders")
+public class Order {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "seller_id", nullable = false)
+    private Long sellerId;
+
+    @Enumerated(EnumType.STRING)   // хранить enum строкой, не ORDINAL
+    @Column(nullable = false)
+    private OrderStatus status;
+
+    @Column(name = "created_at", nullable = false)
+    private Instant createdAt;
+
+    // Ленивая связь по умолчанию (для коллекций FetchType.LAZY — и это правильно)
+    @OneToMany(mappedBy = "order", fetch = FetchType.LAZY)
+    private List<OrderItem> items = new ArrayList<>();
+
+    protected Order() { /* required by JPA */ }
+
+    public Order(Long sellerId) {
+        this.sellerId = sellerId;
+        this.status = OrderStatus.CREATED;
+        this.createdAt = Instant.now();
+    }
+
+    // Изменение состояния — через доменные методы, не через публичные сеттеры
+    public void confirm() {
+        if (status != OrderStatus.CREATED) {
+            throw new IllegalStateException("Cannot confirm order in status " + status);
+        }
+        this.status = OrderStatus.PACKING;
+    }
+
+    public Long getId() { return id; }
+    public Long getSellerId() { return sellerId; }
+    public OrderStatus getStatus() { return status; }
+    public Instant getCreatedAt() { return createdAt; }
+    public List<OrderItem> getItems() { return List.copyOf(items); }
+}
+```
+
+```java
+package com.example.order.model;
+
+public enum OrderStatus {
+    CREATED, PACKING, DELIVERING, COMPLETED, CANCELED
+}
+```
+
+### Репозиторий
+
+```java
+package com.example.order.repository;
+
+import com.example.order.model.Order;
+import com.example.order.model.OrderStatus;
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.EntityGraph;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface OrderRepository extends JpaRepository<Order, Long> {
+
+    // 1. Derived query — Spring генерирует JPQL по имени
+    List<Order> findBySellerIdAndStatus(Long sellerId, OrderStatus status);
+
+    boolean existsBySellerIdAndStatus(Long sellerId, OrderStatus status);
+
+    // 2. Пагинация: Page делает count-запрос, Pageable несёт page/size/sort
+    Page<Order> findBySellerId(Long sellerId, Pageable pageable);
+
+    // 3. @EntityGraph — тянем items одним запросом, лечим N+1
+    @EntityGraph(attributePaths = {"items"})
+    Optional<Order> findWithItemsById(Long id);
+
+    // 4. JPQL с fetch join — альтернатива EntityGraph
+    @Query("select distinct o from Order o join fetch o.items where o.sellerId = :sellerId")
+    List<Order> findBySellerIdWithItems(@Param("sellerId") Long sellerId);
+
+    // 5. Native — специфичный SQL PostgreSQL (interval)
+    @Query(value = "select * from orders o where o.seller_id = :sellerId "
+                 + "and o.created_at > now() - interval '30 days'", nativeQuery = true)
+    List<Order> findRecentBySeller(@Param("sellerId") Long sellerId);
+
+    // 6. Модифицирующий запрос — нужен @Modifying + транзакция на вызывающем методе
+    @Modifying(clearAutomatically = true)
+    @Query("update Order o set o.status = :status where o.id = :id and o.status = :expected")
+    int updateStatusIfCurrent(@Param("id") Long id,
+                              @Param("expected") OrderStatus expected,
+                              @Param("status") OrderStatus status);
+
+    // 7. DTO-проекция через конструктор record прямо в JPQL
+    @Query("select new com.example.order.dto.OrderView(o.id, o.status, o.createdAt) "
+         + "from Order o where o.sellerId = :sellerId and o.createdAt > :after")
+    List<com.example.order.dto.OrderView> findViews(@Param("sellerId") Long sellerId,
+                                                    @Param("after") Instant after);
+}
+```
+
+### DTO-проекция (record)
+
+```java
+package com.example.order.dto;
+
+import com.example.order.model.OrderStatus;
+import java.time.Instant;
+
+public record OrderView(Long id, OrderStatus status, Instant createdAt) {}
+```
+
+### Сервис (конструкторная инъекция + транзакции)
+
+```java
+package com.example.order.service;
+
+import com.example.order.dto.OrderView;
+import com.example.order.model.Order;
+import com.example.order.model.OrderStatus;
+import com.example.order.repository.OrderRepository;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class OrderService {
+
+    private final OrderRepository orderRepository;
+
+    // Конструкторная инъекция: final-поле, легко тестировать, нет скрытых зависимостей
+    public OrderService(OrderRepository orderRepository) {
+        this.orderRepository = orderRepository;
+    }
+
+    @Transactional(readOnly = true)
+    public Page<Order> listBySeller(Long sellerId, int page, int size) {
+        var pageable = PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, "createdAt"));
+        return orderRepository.findBySellerId(sellerId, pageable);
+    }
+
+    @Transactional(readOnly = true)
+    public List<OrderView> recentViews(Long sellerId) {
+        var after = Instant.now().minus(30, ChronoUnit.DAYS);
+        return orderRepository.findViews(sellerId, after);
+    }
+
+    @Transactional
+    public void confirm(Long orderId) {
+        Order order = orderRepository.findById(orderId)
+            .orElseThrow(() -> new IllegalArgumentException("Order not found: " + orderId));
+        order.confirm();  // dirty checking запишет изменение на коммите, save() не нужен
+    }
+
+    // Атомарный переход статуса на уровне БД (optimistic-style guard через WHERE)
+    @Transactional
+    public boolean tryStartDelivery(Long orderId) {
+        int updated = orderRepository.updateStatusIfCurrent(
+            orderId, OrderStatus.PACKING, OrderStatus.DELIVERING);
+        return updated == 1;
+    }
+}
+```
+
+### Контроллер (тонкий, только делегирует)
+
+```java
+package com.example.order.controller;
+
+import com.example.order.dto.OrderView;
+import com.example.order.model.Order;
+import com.example.order.service.OrderService;
+import java.util.List;
+import org.springframework.data.domain.Page;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/orders")
+public class OrderController {
+
+    private final OrderService orderService;
+
+    public OrderController(OrderService orderService) {
+        this.orderService = orderService;
+    }
+
+    @GetMapping
+    public Page<Order> list(@RequestParam Long sellerId,
+                            @RequestParam(defaultValue = "0") int page,
+                            @RequestParam(defaultValue = "20") int size) {
+        return orderService.listBySeller(sellerId, page, size);
+    }
+
+    @GetMapping("/recent")
+    public List<OrderView> recent(@RequestParam Long sellerId) {
+        return orderService.recentViews(sellerId);
+    }
+
+    @PostMapping("/{id}/confirm")
+    public void confirm(@PathVariable Long id) {
+        orderService.confirm(id);
+    }
+}
+```
+
+### Конфигурация (application.yml)
+
+```yaml
+spring:
+  datasource:
+    # Секреты — из переменных окружения / секрет-менеджера, НЕ хардкод в yml
+    url: jdbc:postgresql://${DB_HOST:localhost}:5432/orders
+    username: ${DB_USER}
+    password: ${DB_PASSWORD}
+  jpa:
+    hibernate:
+      ddl-auto: validate          # в проде только validate/none; схему ведёт Liquibase/Flyway
+    open-in-view: false           # ОБЯЗАТЕЛЬНО выключить: иначе транзакция живёт весь HTTP-запрос
+    properties:
+      hibernate:
+        jdbc.batch_size: 50       # батчинг INSERT/UPDATE
+        order_inserts: true
+        order_updates: true
+        # Ловим N+1 на этапе разработки — падаем, если ленивую связь трогают вне транзакции
+        query.fail_on_pagination_over_collection_fetch: true
+    show-sql: false               # для отладки true, но лучше логировать через logger ниже
+logging:
+  level:
+    org.hibernate.SQL: debug              # видеть генерируемый SQL
+    org.hibernate.orm.jdbc.bind: trace    # видеть значения параметров (Hibernate 6)
+```
+
+### Зависимости (build.gradle, фрагмент)
+
+```groovy
+dependencies {
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'org.springframework.boot:spring-boot-starter-web'
+    runtimeOnly 'org.postgresql:postgresql'
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testImplementation 'org.testcontainers:postgresql'
+}
+```
+
+## Частые ошибки / подводные камни
+
+**1. Полевая инъекция вместо конструкторной.** `@Autowired private OrderRepository repo;` мешает делать поле `final`, прячет зависимости, ломает тестируемость (нельзя подставить зависимость без рефлексии/контекста) и допускает создание объекта в невалидном состоянии. Всегда — конструкторная инъекция с `final`-полями (для одного конструктора `@Autowired` даже не нужен).
+
+**2. N+1 незаметно убивает производительность.** Список из 100 заказов + обращение к `order.getItems()` в цикле = 101 запрос. На дев-базе с 10 строками не видно, на проде — таймауты. Лечи `@EntityGraph`/fetch join там, где точно нужны связанные данные, или DTO-проекцией, если данные связи не нужны вовсе. Включи `fail_on_pagination_over_collection_fetch` и логируй SQL, чтобы ловить это на разработке.
+
+**3. `@Transactional` на private-методе или через self-invocation.** Прокси Spring перехватывает только `public`-вызовы **через бин**. `@Transactional private void save()` не откроет транзакцию вообще; `public` метод, вызванный как `this.otherTransactional()`, — тоже. Выноси транзакционный метод в отдельный бин или вызывай через инжектированную ссылку. (Подробнее — в правилах архитектуры проекта.)
+
+**4. `FetchType.EAGER` везде «чтобы не падало».** EAGER на связях означает, что связь тянется **всегда**, даже когда не нужна — раздувает запросы, порождает скрытые join'ы и тот же N+1 при `findAll`. Держи связи `LAZY` (для коллекций это дефолт), а нужные данные подтягивай точечно через `@EntityGraph`/fetch join под конкретный сценарий.
+
+**5. `open-in-view: true` (дефолт Spring Boot!).** Оставляет Hibernate-сессию открытой на весь HTTP-запрос, чтобы ленивые связи «волшебно» подгружались в контроллере/сериализаторе. Цена: транзакция/соединение держится дольше, N+1 переезжает в слой сериализации JSON, границы транзакций размываются. Ставь `spring.jpa.open-in-view: false` и грузи всё нужное явно в сервисном слое.
+
+**6. Секреты в конфиге и `ddl-auto: update`/`create` в проде.** Пароль БД в `application.yml`, закоммиченном в git, — утечка. Бери из переменных окружения/секрет-менеджера. А `ddl-auto: update` даёт Hibernate менять схему прода на лету — непредсказуемо и опасно; в проде только `validate`/`none`, а схему ведёт Liquibase/Flyway отдельными миграциями.
+
+**7. Отдача JPA-сущностей наружу и `LazyInitializationException`.** Вернул сущность с ленивой коллекцией из контроллера — при сериализации вне транзакции (с `open-in-view: false`) получишь `LazyInitializationException`; с включённым OSIV — скрытый N+1. Решение — DTO/проекции, собранные внутри транзакции.
+
+**8. `Page` там, где хватило бы `Slice`.** `Page` всегда делает дополнительный `count(*)` — на больших таблицах это заметно. Если UI не показывает «страница X из Y», а просто «загрузить ещё» — используй `Slice` и сэкономь count-запрос.
+
+## Практическая задача
+
+**Контекст.** Ты пишешь бэкенд кабинета продавца. Есть таблица `orders` (сущность `Order` со связью `@OneToMany` на `OrderItem`) и таблица `order_items`. Фронт кабинета показывает список заказов продавца с фильтром по статусу, постранично, с превью числа позиций в каждом заказе. Сейчас endpoint отдаёт всю сущность `Order` целиком, грузит все заказы разом и в шаблоне дёргает `order.getItems().size()` — на продавце с 5000 заказов страница открывается 8 секунд, в логах видно сотни SQL-запросов.
+
+**Дано:**
+- Сущности `Order(id, sellerId, status, createdAt, items)` и `OrderItem(id, order, sku, quantity)`.
+- `OrderStatus` — enum.
+- Работающий Spring Boot 3.x + PostgreSQL проект, репозиторий пока пустой (`extends JpaRepository`).
+
+**Задание.** Спроектировать выдачу списка заказов так, чтобы она была быстрой и корректной:
+
+1. Реализуй endpoint `GET /api/v1/orders?sellerId=&status=&page=&size=`, возвращающий **страницу** заказов с сортировкой по `createdAt` DESC.
+2. Наружу отдаётся **не сущность**, а DTO/проекция: `orderId`, `status`, `createdAt`, `itemsCount` (число позиций). Сущность `Order` за пределы сервисного слоя не выходит.
+3. `itemsCount` должен считаться **без N+1** — не подгружай коллекцию `items` в цикле.
+4. Endpoint отдаёт `Page` с корректным `totalElements`.
+5. Добавь отдельный метод «детали заказа по id» с подгрузкой позиций **одним запросом** (fetch join или `@EntityGraph`), возвращающий DTO с массивом позиций.
+
+**Критерии приёмки:**
+- В логах Hibernate на запрос списка из N заказов — **фиксированное число запросов** (1 на данные + 1 на count), а не N+1. Проверь через `logging.level.org.hibernate.SQL: debug`.
+- `spring.jpa.open-in-view: false` в конфиге, и при этом сериализация не падает с `LazyInitializationException`.
+- Инъекция зависимостей — только конструкторная, поля `final`.
+- Транзакции на чтениях помечены `@Transactional(readOnly = true)`.
+- Endpoint деталей заказа делает ровно **один** SQL-запрос (проверь по логам), несмотря на подгрузку `items`.
+
+**Подсказки (без готового решения):**
+- `itemsCount` удобно считать прямо в JPQL: `select new ...Dto(o.id, o.status, o.createdAt, size(o.items)) ...` — функция `size()` превращается в подзапрос/агрегат и не грузит коллекцию. Альтернатива — `count`-проекция с `group by`.
+- Для страницы с проекцией сигнатура репозитория: `Page<OrderListDto> findBySellerIdAndStatus(Long sellerId, OrderStatus status, Pageable pageable)` — но с конструкторной JPQL-проекцией понадобится явный `@Query` + отдельный `countQuery`.
+- Для деталей — `@EntityGraph(attributePaths = "items")` на методе, возвращающем `Optional<Order>`, затем маппинг в DTO **внутри** транзакции.
+- `Pageable` собери в сервисе через `PageRequest.of(page, size, Sort.by(DESC, "createdAt"))`, а не парси сортировку в контроллере.
+- Помни про декартово произведение: fetch join одной коллекции — ок; если однажды понадобится тянуть две коллекции сразу — это уже `@BatchSize` или два запроса.
+
+Если решишь добавить идемпотентность массовых операций над заказами, ретраи при конфликте статусов или rate limiting на endpoint — это уже смежная тема роадмапа, раздел «**Надёжность и архитектура**».
+
+## Что почитать
+
+- [Spring Data JPA — Reference Documentation](https://docs.spring.io/spring-data/jpa/reference/jpa.html) — официальная дока: derived queries, `@Query`, проекции, `Pageable`, кастомные реализации.
+- [Spring Guide: Accessing Data with JPA](https://spring.io/guides/gs/accessing-data-jpa) — быстрый старт от команды Spring на актуальном Boot 3.
+- [Hibernate 6 ORM — User Guide](https://docs.jboss.org/hibernate/orm/6.4/userguide/html_single/Hibernate_User_Guide.html) — как устроено под капотом: fetching-стратегии, batch fetching, dirty checking, N+1.
+- [Baeldung: Spring Data JPA Guide](https://www.baeldung.com/the-persistence-layer-with-spring-data-jpa) — практические примеры проекций, пагинации и решения N+1.

--- a/src/main/resources/other/spring/spring-security.md
+++ b/src/main/resources/other/spring/spring-security.md
@@ -1,0 +1,394 @@
+# Spring Security
+
+## Зачем это нужно / какую проблему решает
+
+Представь: ты выкатил REST API интернет-магазина. `GET /api/orders/{id}` возвращает заказ, `DELETE /api/orders/{id}` удаляет его, `GET /api/admin/reports` отдаёт выручку за месяц. Пока ты тестируешь локально — всё прекрасно. Потом кто-то делает `curl https://shop.example.com/api/admin/reports` без единого токена и получает финансы компании. А ещё покупатель Вася меняет `{id}` в URL и читает чужой заказ Пети.
+
+Проблема не в бизнес-логике — она корректна. Проблема в том, что **каждый эндпоинт должен знать, кто его дёргает и имеет ли право**. Писать это руками в каждом контроллере (`if (currentUser == null) return 401; if (!currentUser.isAdmin()) return 403;`) — путь к катастрофе: ты забудешь проверку ровно в том эндпоинте, где она критична, продублируешь логику 200 раз и не сможешь её единообразно поменять.
+
+Spring Security решает это, вставляя **цепочку фильтров перед контроллерами**. Каждый HTTP-запрос проходит сквозь неё: сначала выясняется, *кто ты* (аутентификация), затем — *что тебе можно* (авторизация). Контроллер получает управление, только если запрос легитимен. Ты описываешь правила декларативно в одном месте, а не размазываешь `if`-ы по коду.
+
+Две задачи, которые нужно чётко разделять:
+
+- **Аутентификация (authentication)** — «кто ты?». Проверка личности: логин/пароль, JWT-токен, сессионная кука, mTLS-сертификат. Результат — объект `Authentication` с твоими данными и ролями.
+- **Авторизация (authorization)** — «что тебе можно?». Уже зная, кто ты, система решает: пустить на `/api/admin/**` или ответить `403 Forbidden`.
+
+Классика путаницы новичков: `401 Unauthorized` — это на самом деле про **аутентификацию** («ты не представился / токен невалиден»), а `403 Forbidden` — про **авторизацию** («мы знаем, кто ты, но сюда нельзя»). Названия HTTP-статусов исторически неудачные — держи в голове, что 401 = «залогинься», 403 = «тебе не положено».
+
+## Ключевые понятия
+
+### SecurityFilterChain — сердце конфигурации
+
+Spring Security 6 (Spring Boot 3.x) отказался от `WebSecurityConfigurerAdapter` — его **удалили**. Сейчас конфигурация строится вокруг бина `SecurityFilterChain`: ты объявляешь `@Bean`, который через fluent-API `HttpSecurity` описывает правила. Это компонентный подход вместо наследования: несколько цепочек можно объявить для разных групп путей и упорядочить через `@Order`.
+
+Внутри — линейка сервлет-фильтров (`SecurityFilterChain` буквально список `Filter`-ов). Запрос идёт по ним: `CorsFilter` → `CsrfFilter` → фильтр аутентификации → `AuthorizationFilter` → твой `DispatcherServlet`. Понимание, что это **фильтры до контроллера**, снимает 90% магии.
+
+### Authentication и SecurityContext
+
+Результат успешной аутентификации — объект `Authentication` (кто, какие `GrantedAuthority`). Он кладётся в `SecurityContext`, который живёт в `SecurityContextHolder` (по умолчанию — `ThreadLocal` на время обработки запроса). Из любого места кода достаёшь текущего пользователя, но лучше — через инъекцию `@AuthenticationPrincipal`, а не через статический холдер.
+
+### UserDetailsService и UserDetails
+
+Где брать пользователей? Интерфейс `UserDetailsService` c единственным методом `loadUserByUsername(String)` — это твой мост к БД. Он возвращает `UserDetails`: логин, **хэш** пароля, набор `authorities`. Spring сам сравнит присланный пароль с хэшем через `PasswordEncoder`. Ты реализуешь `UserDetailsService` поверх своего JPA-репозитория — и Security ничего не знает про твою таблицу `users`, только про контракт.
+
+### PasswordEncoder и BCrypt
+
+Пароли **никогда** не хранят в открытом виде и не хэшируют «голым» SHA-256. Нужен медленный адаптивный алгоритм с солью: **BCrypt** (или Argon2, SCrypt, PBKDF2). `BCryptPasswordEncoder` генерирует соль сам, зашивает её в строку хэша (`$2a$10$...`) и настраивается по «стоимости» (work factor, по умолчанию 10 — это 2^10 итераций). При росте железа поднимаешь фактор — старые хэши остаются валидными. Для новых проектов, где нужна миграция алгоритмов, есть `DelegatingPasswordEncoder` (префикс `{bcrypt}`, `{argon2}` в хэше).
+
+### Form login vs stateless (JWT / OAuth2 Resource Server)
+
+Два принципиально разных мира:
+
+- **Form login + сессия** — классика для server-rendered приложений (Thymeleaf). После логина сервер создаёт `HttpSession`, кладёт `JSESSIONID` в куку, состояние хранится на сервере. Stateful.
+- **Stateless (JWT / OAuth2 Resource Server)** — для SPA, мобилок, микросервисов. Сервер **не хранит сессию**. Клиент на каждый запрос шлёт `Authorization: Bearer <token>`. Сервер проверяет подпись токена (обычно JWT, подписанный внешним Identity Provider — Keycloak, Auth0, Cognito) и восстанавливает `Authentication` из claim'ов. Ничего не помнит между запросами. Идеально масштабируется горизонтально — любой инстанс обработает запрос без общего session-store.
+
+В микросервисах почти всегда второй вариант: `spring-boot-starter-oauth2-resource-server`, ты только указываешь, где взять публичный ключ (`issuer-uri`), а валидацию подписи и парсинг claim'ов Spring делает сам.
+
+### Method security (@PreAuthorize)
+
+Правила на уровне URL (`requestMatchers`) грубоваты, когда доступ зависит от данных: «редактировать заказ может только его владелец». Тут включается **method security**: `@EnableMethodSecurity` + аннотации `@PreAuthorize` / `@PostAuthorize` прямо на методах сервиса. Внутри — SpEL-выражения: `@PreAuthorize("hasRole('ADMIN') or #order.ownerId == authentication.principal.id")`. Проверка навешивается через Spring AOP-прокси — поэтому работает только на публичных методах бина, вызванных **снаружи** (та же self-invocation проблема, что и у `@Transactional`).
+
+### CSRF и CORS кратко
+
+- **CSRF (Cross-Site Request Forgery)** — атака, где чужой сайт заставляет браузер жертвы отправить запрос с её кукой. Актуально только для **cookie-based** аутентификации (form login). Spring Security включает CSRF-защиту по умолчанию: на изменяющие запросы (POST/PUT/DELETE) требуется CSRF-токен. Для **stateless JWT** API, где нет кук, CSRF не работает как вектор → защиту отключают (`csrf(csrf -> csrf.disable())`). Это не «отключить безопасность», это «убрать неприменимый механизм».
+- **CORS (Cross-Origin Resource Sharing)** — браузерный механизм: можно ли фронту с `app.example.com` дёргать API на `api.example.com`. Настраивается бином `CorsConfigurationSource`. Путать с CSRF — типичная ошибка: CORS разрешает легитимные кросс-доменные запросы, CSRF защищает от нелегитимных.
+
+## Примеры на Java
+
+Разберём **stateless JWT-ресурс-сервер** (самый частый кейс для микросервиса) и параллельно покажем локальную аутентификацию через `UserDetailsService` + BCrypt — чтобы было видно обе стороны.
+
+### JPA-сущность пользователя
+
+```java
+package com.example.shop.user;
+
+import jakarta.persistence.*;
+import java.util.Set;
+
+@Entity
+@Table(name = "users")
+public class UserEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, unique = true)
+    private String username;
+
+    // храним BCrypt-хэш, НЕ пароль в открытом виде
+    @Column(name = "password_hash", nullable = false)
+    private String passwordHash;
+
+    // роли пользователя; @ElementCollection тянет их отдельной таблицей user_roles
+    @ElementCollection(fetch = FetchType.EAGER) // роли маленькие и нужны всегда при логине — EAGER здесь оправдан
+    @CollectionTable(name = "user_roles", joinColumns = @JoinColumn(name = "user_id"))
+    @Column(name = "role")
+    @Enumerated(EnumType.STRING)
+    private Set<Role> roles;
+
+    protected UserEntity() { } // требуется JPA
+
+    public UserEntity(String username, String passwordHash, Set<Role> roles) {
+        this.username = username;
+        this.passwordHash = passwordHash;
+        this.roles = roles;
+    }
+
+    public Long getId() { return id; }
+    public String getUsername() { return username; }
+    public String getPasswordHash() { return passwordHash; }
+    public Set<Role> getRoles() { return roles; }
+}
+```
+
+```java
+package com.example.shop.user;
+
+public enum Role {
+    USER,
+    ADMIN
+}
+```
+
+### Репозиторий
+
+```java
+package com.example.shop.user;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import java.util.Optional;
+
+public interface UserRepository extends JpaRepository<UserEntity, Long> {
+    Optional<UserEntity> findByUsername(String username);
+}
+```
+
+### UserDetailsService поверх БД
+
+```java
+package com.example.shop.user;
+
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.*;
+import org.springframework.stereotype.Service;
+
+@Service
+public class DbUserDetailsService implements UserDetailsService {
+
+    private final UserRepository userRepository;
+
+    // конструкторная инъекция — не @Autowired на поле
+    public DbUserDetailsService(UserRepository userRepository) {
+        this.userRepository = userRepository;
+    }
+
+    @Override
+    public UserDetails loadUserByUsername(String username) {
+        var user = userRepository.findByUsername(username)
+            .orElseThrow(() -> new UsernameNotFoundException("User not found: " + username));
+
+        var authorities = user.getRoles().stream()
+            // Spring ждёт префикс ROLE_ для hasRole(...)
+            .map(role -> new SimpleGrantedAuthority("ROLE_" + role.name()))
+            .toList();
+
+        // возвращаем встроенную реализацию UserDetails с ХЭШЕМ пароля
+        return User.withUsername(user.getUsername())
+            .password(user.getPasswordHash())
+            .authorities(authorities)
+            .build();
+    }
+}
+```
+
+### Конфигурация SecurityFilterChain (stateless JWT resource server)
+
+```java
+package com.example.shop.config;
+
+import org.springframework.context.annotation.*;
+import org.springframework.security.config.Customizer;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.web.cors.*;
+import java.util.List;
+
+@Configuration
+@EnableMethodSecurity // включает @PreAuthorize/@PostAuthorize
+public class SecurityConfig {
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        http
+            // CORS — разрешаем фронту ходить в API (бин ниже)
+            .cors(Customizer.withDefaults())
+            // CSRF не нужен для stateless Bearer-token API: нет кук — нет вектора
+            .csrf(csrf -> csrf.disable())
+            // ключевое для stateless: сервер НЕ создаёт HttpSession
+            .sessionManagement(sm -> sm.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+            .authorizeHttpRequests(auth -> auth
+                // публичные эндпоинты
+                .requestMatchers("/api/auth/**", "/actuator/health").permitAll()
+                // только админам
+                .requestMatchers("/api/admin/**").hasRole("ADMIN")
+                // всё остальное — только аутентифицированным
+                .anyRequest().authenticated()
+            )
+            // включаем OAuth2 Resource Server с валидацией JWT
+            .oauth2ResourceServer(oauth -> oauth.jwt(Customizer.withDefaults()));
+
+        return http.build();
+    }
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        // work factor 10 по умолчанию; поднимай при росте железа
+        return new BCryptPasswordEncoder();
+    }
+
+    @Bean
+    public CorsConfigurationSource corsConfigurationSource() {
+        var config = new CorsConfiguration();
+        config.setAllowedOrigins(List.of("https://app.example.com"));
+        config.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE"));
+        config.setAllowedHeaders(List.of("Authorization", "Content-Type"));
+        var source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", config);
+        return source;
+    }
+}
+```
+
+### application.yml — откуда брать ключ для проверки JWT
+
+```yaml
+spring:
+  security:
+    oauth2:
+      resourceserver:
+        jwt:
+          # адрес Identity Provider (Keycloak/Auth0/...);
+          # Spring сам скачает JWKS-ключи и провалидирует подпись токена
+          issuer-uri: https://idp.example.com/realms/shop
+```
+
+### Контроллер с method security
+
+```java
+package com.example.shop.order;
+
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/orders")
+public class OrderController {
+
+    private final OrderService orderService;
+
+    public OrderController(OrderService orderService) {
+        this.orderService = orderService;
+    }
+
+    // @AuthenticationPrincipal достаёт JWT текущего пользователя из SecurityContext
+    @GetMapping("/{id}")
+    public OrderDto getOrder(@PathVariable Long id, @AuthenticationPrincipal Jwt jwt) {
+        // владельца проверяем внутри сервиса (см. @PreAuthorize ниже)
+        return orderService.getForUser(id, jwt.getSubject());
+    }
+
+    // грубая проверка на уровне метода: только ADMIN
+    @PreAuthorize("hasRole('ADMIN')")
+    @DeleteMapping("/{id}")
+    public void deleteOrder(@PathVariable Long id) {
+        orderService.delete(id);
+    }
+}
+```
+
+```java
+package com.example.shop.order;
+
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.stereotype.Service;
+
+@Service
+public class OrderService {
+
+    private final OrderRepository orderRepository;
+
+    public OrderService(OrderRepository orderRepository) {
+        this.orderRepository = orderRepository;
+    }
+
+    // тонкая авторизация «по данным»: пускаем ADMIN ИЛИ владельца заказа.
+    // #id — аргумент метода, доступен в SpEL; проверка через returnObject невозможна
+    // до вызова, поэтому владение проверяем в самом методе (см. ниже) либо @PostAuthorize.
+    @PreAuthorize("hasRole('ADMIN') or @orderSecurity.isOwner(#id, authentication.name)")
+    public OrderDto getForUser(Long id, String subject) {
+        return orderRepository.findById(id)
+            .map(OrderDto::from)
+            .orElseThrow(() -> new OrderNotFoundException(id));
+    }
+
+    public void delete(Long id) {
+        orderRepository.deleteById(id);
+    }
+}
+```
+
+### Регистрация пользователя — как правильно сохранять пароль
+
+```java
+package com.example.shop.auth;
+
+import com.example.shop.user.*;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import java.util.Set;
+
+@Service
+public class RegistrationService {
+
+    private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
+
+    public RegistrationService(UserRepository userRepository, PasswordEncoder passwordEncoder) {
+        this.userRepository = userRepository;
+        this.passwordEncoder = passwordEncoder;
+    }
+
+    public void register(String username, String rawPassword) {
+        // encode() генерирует соль и BCrypt-хэш; в БД уходит только хэш
+        var hash = passwordEncoder.encode(rawPassword);
+        userRepository.save(new UserEntity(username, hash, Set.of(Role.USER)));
+    }
+}
+```
+
+## Частые ошибки / подводные камни
+
+1. **Полевая инъекция вместо конструкторной.** `@Autowired private UserRepository repo;` мешает тестировать, скрывает обязательные зависимости и позволяет создать бин в невалидном состоянии. Всегда — `final`-поля + конструктор (Spring с одним конструктором инъектит без `@Autowired`). Это же требование стайл-гайда в проде.
+
+2. **CSRF отключают там, где он нужен, и наоборот.** Если у тебя server-rendered приложение с form login и `JSESSIONID`-кукой — **не отключай** CSRF, иначе откроешь классическую CSRF-дыру. Если stateless Bearer-token API без кук — CSRF отключить корректно, он неприменим. Решает не «модно/немодно», а **есть ли кука, которую браузер шлёт автоматически**.
+
+3. **`@PreAuthorize` на private-методе или при self-invocation.** Method security работает через Spring AOP-прокси, ровно как `@Transactional`. Аннотация на `private`-методе или на публичном, вызванном через `this.method()` из того же бина, **молча игнорируется** — проверки не будет, дыра открыта. Вызывай через инжектированный бин. (См. раздел роадмапа «Надёжность и архитектура» про прокси и self-invocation.)
+
+4. **Забыли `SessionCreationPolicy.STATELESS` в JWT-API.** Без него Spring на каждый запрос всё равно заводит `HttpSession`, память течёт, а горизонтальное масштабирование ломается на sticky-session. Для токенового API — обязательно `STATELESS`.
+
+5. **Хранение секретов и алгоритм хэширования.** Пароли — только через `PasswordEncoder` (BCrypt/Argon2), никогда не `MessageDigest.getInstance("SHA-256")` без соли и без «медленности». Секреты (issuer, client-secret, ключи БД) — не в `application.yml` в гите, а через переменные окружения / Vault / K8s Secrets. Захардкоженный секрет в конфиге — находка для того, кто получит доступ к репозиторию.
+
+6. **Путаница `hasRole` vs `hasAuthority` и префикс `ROLE_`.** `hasRole("ADMIN")` под капотом ищет authority `ROLE_ADMIN`. Если ты положил в `GrantedAuthority` строку `"ADMIN"` без префикса — `hasRole("ADMIN")` не сработает, а `hasAuthority("ADMIN")` сработает. Держи одно соглашение: роли с префиксом `ROLE_`, права/scope — без.
+
+7. **`permitAll()` не значит «анонимно всегда».** Порядок `requestMatchers` важен: правила проверяются сверху вниз, первый матч выигрывает. Если `anyRequest().authenticated()` окажется выше специфичного `permitAll()`, публичный эндпоинт закроется. Специфичные пути — выше, `anyRequest()` — всегда последним.
+
+## Практическая задача
+
+**Контекст.** Ты пишешь микросервис `notes-service` — хранилище личных заметок. Фронт — SPA на React, ходит в API с `Authorization: Bearer <JWT>`, токены выдаёт корпоративный Keycloak. Сервис должен быть stateless и готов к горизонтальному масштабированию.
+
+**Дано.**
+- Заметка: `id`, `ownerUsername`, `title`, `body`, `createdAt`.
+- В JWT есть claim `preferred_username` (логин) и claim `roles` со значениями `USER` / `ADMIN`.
+- Keycloak доступен по `issuer-uri: https://keycloak.corp.local/realms/notes`.
+- Эндпоинты:
+  - `POST /api/notes` — создать заметку (владелец = текущий пользователь);
+  - `GET /api/notes/{id}` — прочитать;
+  - `DELETE /api/notes/{id}` — удалить;
+  - `GET /api/admin/notes` — список всех заметок всех пользователей;
+  - `GET /actuator/health` — здоровье, публичный.
+
+**ТЗ.**
+1. Настрой `SecurityFilterChain` как OAuth2 Resource Server с валидацией JWT, `STATELESS`-сессиями и выключенным CSRF (обоснуй в комментарии, почему выключен).
+2. `/actuator/health` — публичный; `/api/admin/**` — только `ADMIN`; всё остальное — только аутентифицированным.
+3. Роли из claim `roles` должны превращаться в `ROLE_USER` / `ROLE_ADMIN` (напиши свой `Converter<Jwt, ? extends AbstractAuthenticationToken>` или настрой `JwtAuthenticationConverter`).
+4. Прочитать/удалить заметку может **только её владелец или ADMIN**. Реализуй это через `@PreAuthorize` (не через `if` в контроллере).
+5. Настрой CORS: разрешён только origin `https://notes.corp.local`, методы `GET/POST/DELETE`.
+
+**Критерии приёмки.**
+- Запрос без токена на `/api/notes/1` → `401`.
+- Токен валидного `USER`, который не владелец, на чужую заметку → `403`.
+- Владелец на свою заметку → `200`.
+- `USER` на `/api/admin/notes` → `403`; `ADMIN` → `200`.
+- Любой запрос на `/actuator/health` без токена → `200`.
+- В коде **нет** `HttpSession`, нет проверок владения через `if` в контроллере, нет полевой инъекции.
+
+**Подсказки (без готового решения).**
+- Маппинг claim'а `roles` в authorities — через `JwtAuthenticationConverter` + `JwtGrantedAuthoritiesConverter` или собственную лямбду; не забудь префикс `ROLE_`.
+- Проверку владельца удобно вынести в отдельный бин (`@Component("noteSecurity")`) с методом `boolean isOwner(Long noteId, String username)` и звать его из SpEL: `@PreAuthorize("hasRole('ADMIN') or @noteSecurity.isOwner(#id, authentication.name)")`.
+- Помни про self-invocation: `@PreAuthorize`-метод должен вызываться через прокси (снаружи бина), иначе проверка не сработает.
+- Для функциональных тестов пригодятся `spring-security-test` и `SecurityMockMvcRequestPostProcessors.jwt()` — можно подсунуть JWT с нужными claim'ами без реального Keycloak.
+- Про идемпотентность `POST /api/notes`, ретраи и rate limiting на публичных эндпоинтах — см. раздел роадмапа «Надёжность и архитектура»; здесь фокус только на access control.
+
+## Что почитать
+
+- [Spring Security Reference — Architecture (Servlet)](https://docs.spring.io/spring-security/reference/servlet/architecture.html) — как устроена цепочка фильтров, `SecurityContext`, `Authentication`. Первоисточник.
+- [Spring Security — OAuth2 Resource Server / JWT](https://docs.spring.io/spring-security/reference/servlet/oauth2/resource-server/jwt.html) — официальный гайд по stateless JWT, валидации подписи и `JwtAuthenticationConverter`.
+- [Spring Security — Method Security](https://docs.spring.io/spring-security/reference/servlet/authorization/method-security.html) — `@EnableMethodSecurity`, `@PreAuthorize`/`@PostAuthorize`, SpEL-выражения.
+- [Baeldung — Spring Security with Spring Boot](https://www.baeldung.com/security-spring) — практический хаб со свежими примерами под Spring Security 6 / Boot 3 (form login, JWT, тестирование).


### PR DESCRIPTION
Фаза D из плана пересборки (A✅ B✅ C✅ →D). Написано **отсутствовавшее ядро** роадмапа — раньше README ссылался на несуществующие файлы, а репо обещал «до владения Spring и Hibernate».

Новые разделы (`src/main/resources/other/`), каждый: зачем/проблема → ключевые понятия → примеры на Java (Spring Boot 3, **Jakarta**, Java 21) → грабли → практическая задача → что почитать:
- **Spring:** Core (IoC/DI), Boot 3, Data JPA, Security 6, Cloud
- **Hibernate:** ORM + Criteria API
- **REST API:** дизайн, статус-коды, DTO/валидация, ProblemDetail, идемпотентность

~4300 строк, современный стек (никаких javax / WebSecurityConfigurerAdapter — только как «раньше было / не используйте»). Плейсхолдеры «(в разработке)» в README заменены на живые ссылки.

🤖 Generated with [Claude Code](https://claude.com/claude-code)