### PR TITLE
docs(readme): красивый главный README с hero-баннером и схемой маршрута

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,46 @@
-# Java Roadmap
+<p align="center">
+  <img src="assets/hero.svg" width="900" alt="Java Roadmap — путь Java-разработчика от первого класса до продакшн-надёжности">
+</p>
 
-Добро пожаловать в репозиторий Java Roadmap!
+<p align="center">
+  <img src="https://img.shields.io/badge/Java-21-F89820?style=flat-square" alt="Java 21">
+  <img src="https://img.shields.io/badge/уроков-47-4F8DFB?style=flat-square" alt="47 уроков">
+  <img src="https://img.shields.io/badge/reliability-14%20уроков-FB7185?style=flat-square" alt="Reliability">
+  <img src="https://img.shields.io/badge/схем-30%2B-A78BFA?style=flat-square" alt="30+ схем">
+  <img src="https://img.shields.io/badge/license-MIT-34D399?style=flat-square" alt="MIT">
+</p>
 
-Этот репозиторий служит руководством для изучения Java с нуля до овладения библиотеками Hibernate и Spring.
-Независимо от того, являетесь ли вы новичком или имеете опыт программирования,
-этот план поможет вам пройти через различные этапы изучения разработки на Java.
+<p align="center">
+  <b>План изучения Java с нуля до уровня, на котором пишут и держат живой продакшн.</b><br>
+  Синтаксис и ООП → коллекции и потоки → ORM и Spring → приёмы надёжности, которые отличают инженера от джуна.
+</p>
 
-Визуальный Road map для этого репозитория расположен на https://roadmap.sh/r?id=65c9ad4bd789a518cf2f4cde
+<p align="center">
+  <a href="https://roadmap.sh/r?id=65c9ad4bd789a518cf2f4cde">Визуальный roadmap на roadmap.sh</a>
+</p>
+
+<p align="center">
+  <img src="assets/journey.svg" width="900" alt="Маршрут обучения: Fundamentals → Java Core → Hibernate → Spring → Инструменты → Reliability">
+</p>
+
+<details>
+<summary><b>Как проходить</b></summary>
+
+<br>
+
+- Идите по разделам сверху вниз, каждый следующий опирается на предыдущий
+- Внутри урока: сначала теория и схема, потом код, потом практическая задача под конец
+- Не пропускайте практику. Читать про `Stream API` и написать свой пайплайн это разные навыки
+- Раздел «Надёжность» читайте после Spring, когда уже есть, на что накладывать эти приёмы
+- Застряли, загляните в раздел [Подготовка к собеседованию](#interview), там частые вопросы с разбором
+
+</details>
+
+---
 
 ## Java Fundamentals
+
+<sub>7 уроков · с нуля · синтаксис, конструкции, введение в ООП</sub>
 
 1. [Введение в платформу Java](src/main/resources/java-core/1-java-fundamentals/lvl1/1-java-fundamentals-level-1.md)
 2. [Основные конструкции](src/main/resources/java-core/1-java-fundamentals/lvl2/1-java-fundamentals-level-2.md)
@@ -19,6 +51,8 @@
 7. [Практика ООП и работа со строками](src/main/resources/java-core/1-java-fundamentals/lvl7/1-java-fundamentals-level-7.md)
 
 ## Java Core
+
+<sub>9 уроков · middle · исключения, обобщения, коллекции, сеть, JDBC, Stream API</sub>
 
 1. [Объектно-ориентированное программирование Java](src/main/resources/java-core/2-java-core/lvl1/2-java-core-level-1.md)
 2. [Концепция обработки исключений](src/main/resources/java-core/2-java-core/lvl2/2-java-core-level-2.md)
@@ -32,10 +66,14 @@
 
 ## Hibernate
 
+<sub>2 урока · middle · ORM, маппинг, Criteria API</sub>
+
 1. [Hibernate](src/main/resources/other/hibernate/hibernate.md)
 2. [Hibernate Criteria](src/main/resources/other/hibernate/hibernate-criteria.md)
 
 ## Spring / Spring Boot
+
+<sub>5 уроков · middle · IoC/DI, Boot, Data JPA, Security, Cloud</sub>
 
 1. [Spring (Core, IoC/DI)](src/main/resources/other/spring/spring-core.md)
 2. [Spring Boot 3](src/main/resources/other/spring/spring-boot.md)
@@ -43,7 +81,9 @@
 4. [Spring Security](src/main/resources/other/spring/spring-security.md)
 5. [Spring Cloud](src/main/resources/other/spring/spring-cloud.md)
 
-## Other
+## Инструменты и практики
+
+<sub>паттерны, git, тесты, сборка, инфраструктура, архитектура, REST</sub>
 
 1. [Порождающие шаблоны](src/main/resources/other/patterns/Creational-Patterns.md)
 2. [Структурные паттерны](src/main/resources/other/patterns/Structural-Patterns.md)
@@ -52,41 +92,38 @@
 5. [JUnit](src/main/resources/other/junit/junit.md)
 6. [JUnit Mockito](src/main/resources/other/junit/junit-mockito.md)
 7. [Maven](src/main/resources/other/maven/Maven.md)
-8. [Инфраструктура](src/main/resources/other/infrastructure/infrastructure.md)
-    + СI/СD
-    + Docker
-    + Kubernetes
-    + Jenkins
-9. [Архитектура](src/main/resources/other/architecture/architecture.md)
-    + Монолитная архитектура
-    + Микросервисная архитектура
-    + Виды межсервисного взаимодействия
-    + Архитектурные паттерны
-    + Как покрывать тестами разные уровни программы
+8. [Инфраструктура](src/main/resources/other/infrastructure/infrastructure.md) &mdash; CI/CD · Docker · Kubernetes · Jenkins
+9. [Архитектура](src/main/resources/other/architecture/architecture.md) &mdash; монолит · микросервисы · межсервисное взаимодействие · тестирование уровней
 10. [REST API](src/main/resources/other/rest/rest.md)
 11. Agile _(в разработке)_
 12. Scrum _(в разработке)_
 
 ## Надёжность и архитектура
 
-Приёмы, которые отличают инженера от джуна: продакшн ломается не на алгоритмах, а на сети, дублях, гонках и отказах. Каждый урок — проблема из реального продакшна → теория → механика → пример на Java → грабли → практическая задача под этот приём. [Обзор раздела](src/main/resources/other/reliability/README.md).
+<sub>14 уроков · senior · приёмы, которые держат продакшн под нагрузкой</sub>
 
-1. [Идемпотентность](src/main/resources/other/reliability/01-idempotency.md) — повтор запроса не должен списывать деньги дважды
-2. [Ретраи](src/main/resources/other/reliability/02-retries.md) — безопасно повторять при временных сбоях
-3. [Backoff и jitter](src/main/resources/other/reliability/03-backoff-jitter.md) — не превратить ретраи в retry storm
-4. [Rate limiting](src/main/resources/other/reliability/04-rate-limiting.md) — ограничить частоту, защитить от перегрузки
-5. [Таймауты](src/main/resources/other/reliability/05-timeouts.md) — зависший вызов не должен держать поток вечно
-6. [Circuit Breaker](src/main/resources/other/reliability/06-circuit-breaker.md) — fail fast вместо каскадного отказа
-7. [Bulkhead](src/main/resources/other/reliability/07-bulkhead.md) — изолировать ресурсы по секциям
-8. [Dead Letter Queue](src/main/resources/other/reliability/08-dead-letter-queue.md) — ядовитое сообщение не блокирует очередь
-9. [Дедупликация](src/main/resources/other/reliability/09-deduplication.md) — at-least-once без двойной обработки
-10. [Transactional Outbox](src/main/resources/other/reliability/10-transactional-outbox.md) — решение проблемы dual-write
-11. [Реконциляция](src/main/resources/other/reliability/11-reconciliation.md) — фоновая сверка и починка расхождений
-12. [Saga](src/main/resources/other/reliability/12-saga.md) — распределённые транзакции через компенсации
-13. [Кэширование и инвалидация](src/main/resources/other/reliability/13-caching.md) — быстро, без stale и cache stampede
-14. [Claim и lease](src/main/resources/other/reliability/14-claim-lease.md) — несколько воркеров разбирают таблицу задач без долгих локов
+Продакшн ломается не на алгоритмах, а на сети, дублях, гонках и отказах. Каждый урок построен одинаково: проблема из реального продакшна → теория → механика → пример на Java → грабли → практическая задача под этот приём. [Обзор раздела со схемами](src/main/resources/other/reliability/README.md).
+
+| # | Приём | О чём |
+|---|-------|-------|
+| 1 | [Идемпотентность](src/main/resources/other/reliability/01-idempotency.md) | повтор запроса не должен списывать деньги дважды |
+| 2 | [Ретраи](src/main/resources/other/reliability/02-retries.md) | безопасно повторять при временных сбоях |
+| 3 | [Backoff и jitter](src/main/resources/other/reliability/03-backoff-jitter.md) | не превратить ретраи в retry storm |
+| 4 | [Rate limiting](src/main/resources/other/reliability/04-rate-limiting.md) | ограничить частоту, защитить от перегрузки |
+| 5 | [Таймауты](src/main/resources/other/reliability/05-timeouts.md) | зависший вызов не должен держать поток вечно |
+| 6 | [Circuit Breaker](src/main/resources/other/reliability/06-circuit-breaker.md) | fail fast вместо каскадного отказа |
+| 7 | [Bulkhead](src/main/resources/other/reliability/07-bulkhead.md) | изолировать ресурсы по секциям |
+| 8 | [Dead Letter Queue](src/main/resources/other/reliability/08-dead-letter-queue.md) | ядовитое сообщение не блокирует очередь |
+| 9 | [Дедупликация](src/main/resources/other/reliability/09-deduplication.md) | at-least-once без двойной обработки |
+| 10 | [Transactional Outbox](src/main/resources/other/reliability/10-transactional-outbox.md) | решение проблемы dual-write |
+| 11 | [Реконциляция](src/main/resources/other/reliability/11-reconciliation.md) | фоновая сверка и починка расхождений |
+| 12 | [Saga](src/main/resources/other/reliability/12-saga.md) | распределённые транзакции через компенсации |
+| 13 | [Кэширование и инвалидация](src/main/resources/other/reliability/13-caching.md) | быстро, без stale и cache stampede |
+| 14 | [Claim и lease](src/main/resources/other/reliability/14-claim-lease.md) | воркеры разбирают таблицу задач без долгих локов |
 
 ## Database
+
+Подборка статей на Хабре, чтобы разобраться с индексами, изоляцией и планами запросов:
 
 1. https://habr.com/p/794839/
 2. https://habr.com/p/763648/
@@ -98,13 +135,14 @@
 
 ## Interview
 
-[Подготовка к собеседованию Java Dev](src/main/resources/interview/java-interview.md)
+[Подготовка к собеседованию Java Dev](src/main/resources/interview/java-interview.md) &mdash; частые вопросы с разбором.
+
+---
 
 ## Содействие
 
-Приветствуются ваши вклады! Если вы нашли какие-либо проблемы или у вас есть предложения по улучшению, не стесняйтесь создавать задачу или отправлять запрос на
-включение изменений.
+Нашли ошибку или знаете, как объяснить тему понятнее, заводите issue или присылайте pull request. Правки в текст, новые задачи и схемы приветствуются.
 
 ## Лицензия
 
-Этот проект лицензирован в соответствии с лицензией MIT - см. файл LICENSE для получения дополнительной информации.
+Проект под лицензией MIT, подробности в файле [LICENSE](LICENSE).

--- a/assets/hero.svg
+++ b/assets/hero.svg
@@ -1,0 +1,48 @@
+<svg width="900" height="280" viewBox="0 0 900 280" fill="none" xmlns="http://www.w3.org/2000/svg" font-family="'Inter','Segoe UI',system-ui,-apple-system,sans-serif">
+  <defs>
+    <linearGradient id="hbg" x1="0" y1="0" x2="900" y2="280" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#0A1120"/><stop offset="0.55" stop-color="#0C1730"/><stop offset="1" stop-color="#0E1A38"/>
+    </linearGradient>
+    <linearGradient id="htitle" x1="60" y1="0" x2="620" y2="0" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#7FA9FB"/><stop offset="0.5" stop-color="#A78BFA"/><stop offset="1" stop-color="#34D399"/>
+    </linearGradient>
+    <radialGradient id="hglow" cx="0.78" cy="0.28" r="0.6">
+      <stop stop-color="#4F8DFB" stop-opacity="0.20"/><stop offset="1" stop-color="#4F8DFB" stop-opacity="0"/>
+    </radialGradient>
+  </defs>
+  <rect x="0" y="0" width="900" height="280" rx="22" fill="url(#hbg)"/>
+  <rect x="0" y="0" width="900" height="280" rx="22" fill="url(#hglow)"/>
+
+  <!-- constellation dots -->
+  <g fill="#2E4C82" opacity="0.55">
+    <circle cx="720" cy="60" r="2.5"/><circle cx="790" cy="96" r="2"/><circle cx="836" cy="52" r="2.5"/>
+    <circle cx="768" cy="150" r="2"/><circle cx="700" cy="120" r="1.8"/><circle cx="850" cy="128" r="2"/>
+  </g>
+  <g stroke="#2E4C82" stroke-width="1" opacity="0.4">
+    <line x1="720" y1="60" x2="790" y2="96"/><line x1="790" y1="96" x2="836" y2="52"/>
+    <line x1="790" y1="96" x2="768" y2="150"/><line x1="768" y1="150" x2="850" y2="128"/>
+  </g>
+
+  <text x="60" y="86" font-size="13" font-weight="700" letter-spacing="3" fill="#8FA1BF">ПУТЬ JAVA-РАЗРАБОТЧИКА</text>
+  <text x="58" y="152" font-size="58" font-weight="800" fill="url(#htitle)" letter-spacing="-1">Java Roadmap</text>
+  <text x="60" y="190" font-size="16.5" fill="#AFC0DD">от первого класса до продакшн-надёжности</text>
+
+  <!-- tech chips -->
+  <g font-size="12.5" font-weight="600">
+    <rect x="60" y="216" width="92" height="30" rx="15" fill="#12203B" stroke="#2E4C82"/><text x="106" y="235" fill="#7FA9FB" text-anchor="middle">Java 21</text>
+    <rect x="160" y="216" width="104" height="30" rx="15" fill="#161231" stroke="#4A3E86"/><text x="212" y="235" fill="#B49BFB" text-anchor="middle">Spring Boot</text>
+    <rect x="272" y="216" width="100" height="30" rx="15" fill="#0F3129" stroke="#2C7A65"/><text x="322" y="235" fill="#43D9A3" text-anchor="middle">Hibernate</text>
+    <rect x="380" y="216" width="82" height="30" rx="15" fill="#241C08" stroke="#7A5E1E"/><text x="421" y="235" fill="#F7C948" text-anchor="middle">Kafka</text>
+    <rect x="470" y="216" width="118" height="30" rx="15" fill="#2A0F17" stroke="#7A3141"/><text x="529" y="235" fill="#FB7185" text-anchor="middle">Reliability</text>
+  </g>
+
+  <!-- coffee mark -->
+  <g transform="translate(690,168)" opacity="0.92">
+    <rect x="0" y="18" width="86" height="60" rx="14" fill="#12203B" stroke="#4F8DFB"/>
+    <path d="M86 30 h16 a14 14 0 0 1 0 28 h-16" fill="none" stroke="#4F8DFB" stroke-width="3"/>
+    <g stroke="#7FA9FB" stroke-width="3" stroke-linecap="round" opacity="0.8">
+      <path d="M26 4 q-6 6 0 12"/><path d="M43 2 q-6 6 0 12"/><path d="M60 4 q-6 6 0 12"/>
+    </g>
+    <text x="43" y="58" font-size="26" font-weight="800" fill="#7FA9FB" text-anchor="middle" font-family="'JetBrains Mono',monospace">{ }</text>
+  </g>
+</svg>

--- a/assets/journey.svg
+++ b/assets/journey.svg
@@ -1,0 +1,51 @@
+<svg width="900" height="230" viewBox="0 0 900 230" fill="none" xmlns="http://www.w3.org/2000/svg" font-family="'Inter','Segoe UI',system-ui,-apple-system,sans-serif">
+  <defs>
+    <linearGradient id="jbg" x1="0" y1="0" x2="0" y2="230" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#0A1120"/><stop offset="1" stop-color="#0C1730"/>
+    </linearGradient>
+    <linearGradient id="jline" x1="70" y1="0" x2="830" y2="0" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#4F8DFB"/><stop offset="0.5" stop-color="#A78BFA"/><stop offset="1" stop-color="#FB7185"/>
+    </linearGradient>
+  </defs>
+  <rect x="0" y="0" width="900" height="230" rx="20" fill="url(#jbg)"/>
+  <text x="40" y="40" fill="#8FA1BF" font-size="12.5" font-weight="700" letter-spacing="1.5">МАРШРУТ ОБУЧЕНИЯ</text>
+
+  <!-- path line -->
+  <path d="M78 118 H822" stroke="url(#jline)" stroke-width="3" stroke-linecap="round"/>
+
+  <!-- stations -->
+  <g>
+    <!-- 1 Fundamentals -->
+    <circle cx="90" cy="118" r="15" fill="#12203B" stroke="#4F8DFB" stroke-width="2.5"/>
+    <text x="90" y="123" fill="#7FA9FB" font-size="14" font-weight="800" text-anchor="middle">1</text>
+    <text x="90" y="80" fill="#EAF1FB" font-size="13" font-weight="700" text-anchor="middle">Fundamentals</text>
+    <text x="90" y="162" fill="#7FA9FB" font-size="11.5" text-anchor="middle">7 уроков</text>
+    <!-- 2 Core -->
+    <circle cx="238" cy="118" r="15" fill="#12203B" stroke="#4F8DFB" stroke-width="2.5"/>
+    <text x="238" y="123" fill="#7FA9FB" font-size="14" font-weight="800" text-anchor="middle">2</text>
+    <text x="238" y="80" fill="#EAF1FB" font-size="13" font-weight="700" text-anchor="middle">Java Core</text>
+    <text x="238" y="162" fill="#7FA9FB" font-size="11.5" text-anchor="middle">9 уроков</text>
+    <!-- 3 Hibernate -->
+    <circle cx="386" cy="118" r="15" fill="#0F3129" stroke="#34D399" stroke-width="2.5"/>
+    <text x="386" y="123" fill="#43D9A3" font-size="14" font-weight="800" text-anchor="middle">3</text>
+    <text x="386" y="80" fill="#EAF1FB" font-size="13" font-weight="700" text-anchor="middle">Hibernate</text>
+    <text x="386" y="162" fill="#43D9A3" font-size="11.5" text-anchor="middle">2 урока</text>
+    <!-- 4 Spring -->
+    <circle cx="534" cy="118" r="15" fill="#161231" stroke="#A78BFA" stroke-width="2.5"/>
+    <text x="534" y="123" fill="#B49BFB" font-size="14" font-weight="800" text-anchor="middle">4</text>
+    <text x="534" y="80" fill="#EAF1FB" font-size="13" font-weight="700" text-anchor="middle">Spring</text>
+    <text x="534" y="162" fill="#B49BFB" font-size="11.5" text-anchor="middle">5 уроков</text>
+    <!-- 5 Other -->
+    <circle cx="682" cy="118" r="15" fill="#241C08" stroke="#FBBF24" stroke-width="2.5"/>
+    <text x="682" y="123" fill="#F7C948" font-size="14" font-weight="800" text-anchor="middle">5</text>
+    <text x="682" y="80" fill="#EAF1FB" font-size="13" font-weight="700" text-anchor="middle">Инструменты</text>
+    <text x="682" y="162" fill="#F7C948" font-size="11.5" text-anchor="middle">git · тесты · REST</text>
+    <!-- 6 Reliability -->
+    <circle cx="822" cy="118" r="15" fill="#2A0F17" stroke="#FB7185" stroke-width="2.5"/>
+    <text x="822" y="123" fill="#FB7185" font-size="14" font-weight="800" text-anchor="middle">6</text>
+    <text x="822" y="80" fill="#EAF1FB" font-size="13" font-weight="700" text-anchor="middle">Reliability</text>
+    <text x="822" y="162" fill="#FB7185" font-size="11.5" text-anchor="middle">14 уроков</text>
+  </g>
+
+  <text x="450" y="206" fill="#8194B0" font-size="12.5" text-anchor="middle">от синтаксиса и ООП через ORM и Spring до приёмов, которые держат продакшн под нагрузкой</text>
+</svg>


### PR DESCRIPTION
Пересобрал корневой README под единый дизайн всего роадмапа.

## Что нового
- **Hero-баннер** (`assets/hero.svg`) — градиентный заголовок, тех-чипы (Java 21 · Spring Boot · Hibernate · Kafka · Reliability), созвездие, кофе-маркер с `{ }`
- **Схема маршрута** (`assets/journey.svg`) — 6 станций пути: Fundamentals → Java Core → Hibernate → Spring → Инструменты → Reliability, с числом уроков
- **Бейджи** shields.io в шапке (Java 21, уроков 47, reliability, схем 30+, MIT)
- **Спойлер «Как проходить»** с советами по прохождению
- **Reliability таблицей** — 14 приёмов с колонкой «о чём», читается за один взгляд
- **Человеческий текст** — убран ИИ-приветствие, длинные прочерки, канцелярит

Все ссылки на уроки сохранены и проверены. Обе SVG отрендерены headless-Chrome и проверены визуально.

🤖 Generated with [Claude Code](https://claude.com/claude-code)